### PR TITLE
ITM-106: Post-September demo cleanup tasks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/itm_adm_mock.py
+++ b/itm_adm_mock.py
@@ -9,7 +9,7 @@ def main():
     parser.add_argument('-y', action='store_true', default=False, help='Use a premade yaml scene')
     parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
                         'Specify session type and scenario count. '
-                        'Session type can be test, adept, or soartech. '
+                        'Session type can be eval, adept, or soartech. '
                         'If you want to run through all available scenarios without repeating do not use the scenario_count argument')
     parser.add_argument('--eval', action='store_true', default=False, help=\
                         'Run an eval session')

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -167,7 +167,6 @@ def main():
             )
         while True:
             scenario: Scenario = itm.start_scenario(session_id)
-            #scenario: Scenario = itm.start_scenario(session_id=session_id, scenario_id='st-september-2023-mvp2')
             if scenario.session_complete:
                 break
             alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id)

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -12,7 +12,7 @@ The script starts a session and then enters a loop:
 4. Checks if the scenario state's 'scenario_complete' property is True.
    If it is, then it ends the scenario.
 
-Session types can be 'test', 'adept', or 'soartech'. If the 'eval' 
+Session types can be 'eval', 'adept', or 'soartech'. If the 'eval'
 argument is used, then an eval session type is initiated. 
 It uses argparse to handle command-line arguments for the
 session type, scenario count, and adm_name.
@@ -109,7 +109,7 @@ def main():
     parser.add_argument('--session', nargs='*', default=[], 
                         metavar=('session_type', 'scenario_count'), 
                         help='Specify session type and scenario count. '
-                        'Session type can be test, adept, or soartech. '
+                        'Session type can be eval, adept, or soartech. '
                         'If you want to run through all available scenarios '
                         'without repeating do not use the scenario_count '
                         'argument')
@@ -124,8 +124,8 @@ def main():
     args = parser.parse_args()
     iskdma_training=False
     if args.session:
-        if args.session[0] not in ['soartech', 'adept', 'test']:
-            parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'test'.")
+        if args.session[0] not in ['soartech', 'adept', 'eval']:
+            parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
         else:
             session_type = args.session[0]
     else:
@@ -167,6 +167,7 @@ def main():
             )
         while True:
             scenario: Scenario = itm.start_scenario(session_id)
+            #scenario: Scenario = itm.start_scenario(session_id=session_id, scenario_id='st-september-2023-mvp2')
             if scenario.session_complete:
                 break
             alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -18,7 +18,7 @@ paths:
       - itm-ta2-eval
       summary: Start a new session
       description: Get unique session id for grouping answers from a collection of
-        scenarios/probes together
+        scenarios together
       operationId: start_session
       parameters:
       - name: adm_name
@@ -31,13 +31,13 @@ paths:
           type: string
       - name: session_type
         in: query
-        description: "the type of session to start (`test`, `eval`, or a TA1 name)"
+        description: "the type of session to start (`eval` or a TA1 name)"
         required: true
         style: form
         explode: true
         schema:
           type: string
-          example: test
+          example: eval
       - name: kdma_training
         in: query
         description: whether or not this is a training session with TA2
@@ -49,8 +49,8 @@ paths:
           default: false
       - name: max_scenarios
         in: query
-        description: "the maximum number of scenarios requested, supported only in\
-          \ `test` sessions"
+        description: "the maximum number of scenarios requested, not supported in\
+          \ `eval` sessions"
         required: false
         style: form
         explode: true
@@ -111,10 +111,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Scenario'
+        "400":
+          description: Invalid Session ID
         "403":
           description: Specifying a scenario ID is unauthorized
         "404":
-          description: Session or Scenario ID not found
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -155,9 +157,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/AlignmentTarget'
         "400":
-          description: Scenario Complete
+          description: Scenario Complete or Invalid Session ID
         "404":
-          description: Session or Scenario ID not found
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -197,8 +199,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/State'
+        "400":
+          description: Invalid Session ID
         "404":
-          description: Invalid scenario ID supplied
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -226,7 +230,7 @@ paths:
           type: string
       - name: scenario_id
         in: path
-        description: The ID of the scenario for which to retrieve avaialble actions
+        description: The ID of the scenario for which to retrieve available actions
         required: true
         style: simple
         explode: false
@@ -243,9 +247,9 @@ paths:
                   $ref: '#/components/schemas/Action'
                 x-content-type: application/json
         "400":
-          description: Scenario Complete
+          description: Scenario Complete or Invalid Session ID
         "404":
-          description: Invalid scenario ID supplied
+          description: Scenario ID not found
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -285,7 +289,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/State'
         "400":
-          description: Invalid action or session_id
+          description: Invalid action or Session ID
         "500":
           description: An exception occurred on the server; see returned error string.
           content:
@@ -473,8 +477,8 @@ components:
           example: 5.2
         scenario_complete:
           type: boolean
-          description: set to true if the scenario is complete; subsequent calls to
-            /scenario/probe will return an error code
+          description: set to true if the scenario is complete; subsequent calls involving
+            that scenario will return an error code
           example: false
         mission:
           $ref: '#/components/schemas/Mission'
@@ -770,7 +774,6 @@ components:
           - ALLY
           - FRIEND
           - HOSTILE
-          - EXPECTANT
         demographics:
           $ref: '#/components/schemas/Demographics'
         injuries:
@@ -968,15 +971,11 @@ components:
       required:
       - action_id
       - action_type
-      - scenario_id
       type: object
       properties:
         action_id:
           type: string
           description: action ID
-        scenario_id:
-          type: string
-          description: scenario ID this probe is for
         action_type:
           type: string
           description: The action type taken from a controlled vocabulary
@@ -1029,7 +1028,6 @@ components:
         parameters:
         - treatment: Tourniquet
         - location: right forearm
-        scenario_id: scenario_id
   responses:
     server_error:
       description: An exception occurred on the server; see returned error string.

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -146,7 +146,7 @@ class ItmTa2EvalApi(object):
 
         :param async_req bool
         :param str session_id: a unique session_id, as returned by /ta2/startSession (required)
-        :param str scenario_id: The ID of the scenario for which to retrieve avaialble actions (required)
+        :param str scenario_id: The ID of the scenario for which to retrieve available actions (required)
         :return: list[Action]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -169,7 +169,7 @@ class ItmTa2EvalApi(object):
 
         :param async_req bool
         :param str session_id: a unique session_id, as returned by /ta2/startSession (required)
-        :param str scenario_id: The ID of the scenario for which to retrieve avaialble actions (required)
+        :param str scenario_id: The ID of the scenario for which to retrieve available actions (required)
         :return: list[Action]
                  If the method is called asynchronously,
                  returns the request thread.
@@ -443,7 +443,7 @@ class ItmTa2EvalApi(object):
     def start_session(self, adm_name, session_type, **kwargs):  # noqa: E501
         """Start a new session  # noqa: E501
 
-        Get unique session id for grouping answers from a collection of scenarios/probes together  # noqa: E501
+        Get unique session id for grouping answers from a collection of scenarios together  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.start_session(adm_name, session_type, async_req=True)
@@ -468,7 +468,7 @@ class ItmTa2EvalApi(object):
     def start_session_with_http_info(self, adm_name, session_type, **kwargs):  # noqa: E501
         """Start a new session  # noqa: E501
 
-        Get unique session id for grouping answers from a collection of scenarios/probes together  # noqa: E501
+        Get unique session id for grouping answers from a collection of scenarios together  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
         >>> thread = api.start_session_with_http_info(adm_name, session_type, async_req=True)

--- a/swagger_client/models/action.py
+++ b/swagger_client/models/action.py
@@ -29,7 +29,6 @@ class Action(object):
     """
     swagger_types = {
         'action_id': 'str',
-        'scenario_id': 'str',
         'action_type': 'str',
         'casualty_id': 'str',
         'unstructured': 'str',
@@ -40,7 +39,6 @@ class Action(object):
 
     attribute_map = {
         'action_id': 'action_id',
-        'scenario_id': 'scenario_id',
         'action_type': 'action_type',
         'casualty_id': 'casualty_id',
         'unstructured': 'unstructured',
@@ -49,10 +47,9 @@ class Action(object):
         'parameters': 'parameters'
     }
 
-    def __init__(self, action_id=None, scenario_id=None, action_type=None, casualty_id=None, unstructured=None, justification=None, kdma_association=None, parameters=None):  # noqa: E501
+    def __init__(self, action_id=None, action_type=None, casualty_id=None, unstructured=None, justification=None, kdma_association=None, parameters=None):  # noqa: E501
         """Action - a model defined in Swagger"""  # noqa: E501
         self._action_id = None
-        self._scenario_id = None
         self._action_type = None
         self._casualty_id = None
         self._unstructured = None
@@ -61,7 +58,6 @@ class Action(object):
         self._parameters = None
         self.discriminator = None
         self.action_id = action_id
-        self.scenario_id = scenario_id
         self.action_type = action_type
         if casualty_id is not None:
             self.casualty_id = casualty_id
@@ -98,31 +94,6 @@ class Action(object):
             raise ValueError("Invalid value for `action_id`, must not be `None`")  # noqa: E501
 
         self._action_id = action_id
-
-    @property
-    def scenario_id(self):
-        """Gets the scenario_id of this Action.  # noqa: E501
-
-        scenario ID this probe is for  # noqa: E501
-
-        :return: The scenario_id of this Action.  # noqa: E501
-        :rtype: str
-        """
-        return self._scenario_id
-
-    @scenario_id.setter
-    def scenario_id(self, scenario_id):
-        """Sets the scenario_id of this Action.
-
-        scenario ID this probe is for  # noqa: E501
-
-        :param scenario_id: The scenario_id of this Action.  # noqa: E501
-        :type: str
-        """
-        if scenario_id is None:
-            raise ValueError("Invalid value for `scenario_id`, must not be `None`")  # noqa: E501
-
-        self._scenario_id = scenario_id
 
     @property
     def action_type(self):

--- a/swagger_client/models/casualty.py
+++ b/swagger_client/models/casualty.py
@@ -173,7 +173,7 @@ class Casualty(object):
         :param relationship: The relationship of this Casualty.  # noqa: E501
         :type: str
         """
-        allowed_values = ["NONE", "ALLY", "FRIEND", "HOSTILE", "EXPECTANT"]  # noqa: E501
+        allowed_values = ["NONE", "ALLY", "FRIEND", "HOSTILE"]  # noqa: E501
         if relationship not in allowed_values:
             raise ValueError(
                 "Invalid value for `relationship` ({0}), must be one of {1}"  # noqa: E501

--- a/swagger_client/models/state.py
+++ b/swagger_client/models/state.py
@@ -128,7 +128,7 @@ class State(object):
     def scenario_complete(self):
         """Gets the scenario_complete of this State.  # noqa: E501
 
-        set to true if the scenario is complete; subsequent calls to /scenario/probe will return an error code  # noqa: E501
+        set to true if the scenario is complete; subsequent calls involving that scenario will return an error code  # noqa: E501
 
         :return: The scenario_complete of this State.  # noqa: E501
         :rtype: bool
@@ -139,7 +139,7 @@ class State(object):
     def scenario_complete(self, scenario_complete):
         """Sets the scenario_complete of this State.
 
-        set to true if the scenario is complete; subsequent calls to /scenario/probe will return an error code  # noqa: E501
+        set to true if the scenario is complete; subsequent calls involving that scenario will return an error code  # noqa: E501
 
         :param scenario_complete: The scenario_complete of this State.  # noqa: E501
         :type: bool


### PR DESCRIPTION
Fixes a few things that were discovered after the final September release of the TA3 server and ADM client:
* Audit every description in the yaml files and ensure no reference to mvp, probes, and other MVP-1 phenomena.
* Remove `EXPECTANT` from the relationship enum.
* Remove `scenario_id` from the `Action` class and from the `assoc_action` in the configured probe options.  It’s not needed, and ADMs should simply use the `scenario_id` they received from `start_scenario`.  Update the client appropriately.
* Sync the return codes between the YAML configuration and the server code.  Specifically, specifying an invalid `session_id` should result in a `400`, not a `404` return code.
* Remove unused  `test` session type.