### PR TITLE
ITM-141: Extract DB component

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,16 @@ pip3 install -r requirements.txt
  Run `itm_minimal_runner.py` in the root directory:
 
 ```
-usage: itm_minimal_runner.py [-h] [--save] --adm_name ADM_NAME [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
+usage: itm_minimal_runner.py [-h] --adm_name ADM_NAME [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
 
 Runs ADM scenarios.
 
 options:
   -h, --help            show this help message and exit
   --adm_name ADM_NAME   Specify the ADM name
-  --save                Tell the ADM server to save session history.  Enabled if --eval is set.
   --session [session_type [scenario_count ...]]
                         Specify session type and scenario count. Session type can be test, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument
-  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified. Implies --save.
+  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified.
   --kdma_training       Put the server in training mode in which it shows the kdma association for each action choice.
                         Not supported in eval sessions.
 ```
@@ -69,16 +68,15 @@ The Human input simulator is used for testing specific action/parameter sequence
 Inside the root directory, run `itm_human_input.py`:
 
 ```
-usage: itm_human_input.py [-h] [--save] [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
+usage: itm_human_input.py [-h] [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
 
 Runs Human input simulator.
 
 options:
   -h, --help            show this help message and exit
-  --save                Tell the ADM server to save session history.  Enabled if --eval is set.
   --session [session_type [scenario_count ...]]
                         Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
-  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified. Implies --save.
+  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified.
   --kdma_training       Put the server in training mode in which it shows the kdma association for each action choice.
                         Not supported in eval sessions.
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ pip3 install -r requirements.txt
 
 ```
 
+ In order to hit a non-locally running server (localhost) set the below environment variables:
+ - TA3_PORT (Default: 8080)
+ - TA3_HOSTNAME (Default: 127.0.0.1)
+
 ### Running the ADM minimal runner
 
  To see additional details regarding modifying this minimal runner to be a TA2 client, see the comments at the top of `itm_minimal_runner.py`.
@@ -43,23 +47,20 @@ pip3 install -r requirements.txt
  Run `itm_minimal_runner.py` in the root directory:
 
 ```
-usage: itm_minimal_runner.py [-h] --adm_name ADM_NAME [--session [session_type [scenario_count ...]]] [--eval]
+usage: itm_minimal_runner.py [-h] [--save] --adm_name ADM_NAME [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
 
 Runs ADM scenarios.
 
 options:
   -h, --help            show this help message and exit
   --adm_name ADM_NAME   Specify the ADM name
+  --save                Tell the ADM server to save session history.  Enabled if --eval is set.
   --session [session_type [scenario_count ...]]
                         Specify session type and scenario count. Session type can be test, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument
-  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified. Implies --db.
-  --kdma_training [KDMA_TRAINING]
-                        Put the server in training mode in which it shows the kdma association for each action choice.  True or False.
+  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified. Implies --save.
+  --kdma_training       Put the server in training mode in which it shows the kdma association for each action choice.
+                        Not supported in eval sessions.
 ```
-## Hitting a remote TA3 Server
- In order to hit a non-locally running server (localhost) set the below environment variables:
- - TA3_PORT(Default: 8080)
- - TA3_HOSTNAME (Default: 127.0.0.1)
  
 ### Running the Human input simulator
 
@@ -68,16 +69,18 @@ The Human input simulator is used for testing specific action/parameter sequence
 Inside the root directory, run `itm_human_input.py`:
 
 ```
-usage: itm_human_input.py [-h] [--db] [--session [session_type [scenario_count ...]]] [--eval]
+usage: itm_human_input.py [-h] [--save] [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
 
 Runs Human input simulator.
 
 options:
   -h, --help            show this help message and exit
-  --db                  Put the output in the MongoDB (ensure that the itm_dashboard docker container is running) and save a json output file locally inside itm_server/itm_mvp_local_output/
+  --save                Tell the ADM server to save session history.  Enabled if --eval is set.
   --session [session_type [scenario_count ...]]
                         Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
-  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified. Implies --db.
+  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified. Implies --save.
+  --kdma_training       Put the server in training mode in which it shows the kdma association for each action choice.
+                        Not supported in eval sessions.
 ```
 
 ### Available Actions

--- a/itm/itm_adm_scenario_runner.py
+++ b/itm/itm_adm_scenario_runner.py
@@ -67,15 +67,16 @@ class ADMKnowledge:
 
 class ADMScenarioRunner(ScenarioRunner):
 
-    def __init__(self, save_to_db, scene_type, session_type=None,
-                 max_scenarios=0, eval_mode=False):
+    def __init__(self, session_type, save_history=False, max_scenarios=0):
         super().__init__()
         self.session_id = None
-        self.adm_name = scene_type + "ITM ADM4" + save_to_db
+        self.adm_name = "ITM ADM"
+        self.eval_mode = session_type == 'eval'
+        if save_history and not self.eval_mode:
+            self.adm_name += "_save_"
         self.adm_knowledge: ADMKnowledge = None
         self.session_type = session_type
         self.max_scenarios = max_scenarios
-        self.eval_mode = eval_mode
         self.scenarios_run = 0
         self.total_actions_taken = 0
 

--- a/itm/itm_adm_scenario_runner.py
+++ b/itm/itm_adm_scenario_runner.py
@@ -67,13 +67,11 @@ class ADMKnowledge:
 
 class ADMScenarioRunner(ScenarioRunner):
 
-    def __init__(self, session_type, save_history=False, max_scenarios=0):
+    def __init__(self, session_type, max_scenarios=0):
         super().__init__()
         self.session_id = None
         self.adm_name = "ITM ADM"
         self.eval_mode = session_type == 'eval'
-        if save_history and not self.eval_mode:
-            self.adm_name += "_save_"
         self.adm_knowledge: ADMKnowledge = None
         self.session_type = session_type
         self.max_scenarios = max_scenarios

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -26,11 +26,9 @@ class TagTypes(Enum):
 ACTIONS_WITHOUT_CHARACTERS = ["DIRECT_MOBILE_CHARACTERS", "END_SCENARIO", "SITREP"]
 
 class ITMHumanScenarioRunner(ScenarioRunner):
-    def __init__(self, session_type, save_history=False, kdma_training=False, max_scenarios=-1):
+    def __init__(self, session_type, kdma_training=False, max_scenarios=-1):
         super().__init__()
         self.username = session_type + " ITM Human"
-        if save_history and not session_type == 'eval':
-            self.username += "_save_"
         self.session_type = session_type
         self.kdma_training = kdma_training
         if max_scenarios > 0:

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -26,9 +26,11 @@ class TagTypes(Enum):
 ACTIONS_WITHOUT_CHARACTERS = ["DIRECT_MOBILE_CHARACTERS", "END_SCENARIO", "SITREP"]
 
 class ITMHumanScenarioRunner(ScenarioRunner):
-    def __init__(self, save_to_db, session_type, kdma_training=False, max_scenarios=-1):
+    def __init__(self, session_type, save_history=False, kdma_training=False, max_scenarios=-1):
         super().__init__()
-        self.username = session_type + "ITM Human" + save_to_db
+        self.username = session_type + " ITM Human"
+        if save_history and not session_type == 'eval':
+            self.username += "_save_"
         self.session_type = session_type
         self.kdma_training = kdma_training
         if max_scenarios > 0:
@@ -171,12 +173,12 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             response = "Scenario is already started."
         return response
 
-    def start_session_operation(self, temp_username):
+    def start_session_operation(self, username):
         if self.session_id == None:
             if self.max_scenarios == None:
-                self.session_id = self.itm.start_session(temp_username, self.session_type, kdma_training=self.kdma_training)
+                self.session_id = self.itm.start_session(username, self.session_type, kdma_training=self.kdma_training)
             else:
-                self.session_id = self.itm.start_session(temp_username, self.session_type, kdma_training=self.kdma_training, max_scenarios=self.max_scenarios)
+                self.session_id = self.itm.start_session(username, self.session_type, kdma_training=self.kdma_training, max_scenarios=self.max_scenarios)
             response = self.session_id
         else:
             response = "Session is already started."
@@ -294,7 +296,7 @@ class ITMHumanScenarioRunner(ScenarioRunner):
 
         if command in self.get_full_string_and_shortcut(CommandOption.QUIT):
             self.session_complete = True # if there are no more scenarios, then the session is over
-            print("Quitting session-- server will not save output for current scenario to DB.")
+            print("Quitting session-- server will not save history for current scenario if it was enabled.")
         elif isinstance(response, State):
             self.medical_supplies = response.supplies
             if response.scenario_complete == True:

--- a/itm_adm_mock.py
+++ b/itm_adm_mock.py
@@ -3,8 +3,6 @@ from itm import ADMScenarioRunner
 
 def main():
     parser = argparse.ArgumentParser(description='Runs ADM scenarios.')
-    parser.add_argument('--save', action='store_true', default=False, help=\
-                        'Tell the ADM server to save session history.')
     parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
                         'Specify session type and scenario count. '
                         'Session type can be eval, adept, or soartech. '
@@ -25,7 +23,7 @@ def main():
         session_type = 'eval'
     scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
 
-    adm = ADMScenarioRunner(session_type, args.save, scenario_count)
+    adm = ADMScenarioRunner(session_type, scenario_count)
     adm.run()
 
 if __name__ == "__main__":

--- a/itm_adm_mock.py
+++ b/itm_adm_mock.py
@@ -3,10 +3,8 @@ from itm import ADMScenarioRunner
 
 def main():
     parser = argparse.ArgumentParser(description='Runs ADM scenarios.')
-    parser.add_argument('--db', action='store_true', default=False, help=\
-                        'Put the scene in the MongoDB and save a json output file locally inside itm_server/itm_mvp_local_output/')
-    parser.add_argument('-r', action='store_true', default=False, help='Use a randomly generated scene')
-    parser.add_argument('-y', action='store_true', default=False, help='Use a premade yaml scene')
+    parser.add_argument('--save', action='store_true', default=False, help=\
+                        'Tell the ADM server to save session history.')
     parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
                         'Specify session type and scenario count. '
                         'Session type can be eval, adept, or soartech. '
@@ -16,12 +14,18 @@ def main():
 
     args = parser.parse_args()
 
-    scene_type = "_random_" if args.r else ""
-    use_db = "_db_" if args.db else ""
-    session_type = args.session[0] if args.session else ""
+    if args.session:
+        if args.session[0] not in ['soartech', 'adept', 'eval']:
+            parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
+        else:
+            session_type = args.session[0]
+    else:
+        session_type = 'eval'
+    if args.eval:
+        session_type = 'eval'
     scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
 
-    adm = ADMScenarioRunner(use_db, scene_type, session_type, scenario_count, args.eval)
+    adm = ADMScenarioRunner(session_type, args.save, scenario_count)
     adm.run()
 
 if __name__ == "__main__":

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -5,8 +5,8 @@ from itm import ITMHumanScenarioRunner
 def main():
 
     parser = argparse.ArgumentParser(description='Runs Human input simulator.')
-    parser.add_argument('--db', action='store_true', default=False, help=\
-                        "Put the output in the MongoDB (ensure that the itm_dashboard docker container is running) and save a json output file locally inside itm_server/itm_mvp_local_output/")
+    parser.add_argument('--save', action='store_true', default=False, help=\
+                        'Tell the ADM server to save session history.')
     parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
                         'Specify session type and scenario count. '
                         'Session type can be eval, adept, or soartech. '
@@ -14,13 +14,12 @@ def main():
     parser.add_argument('--eval', action='store_true', default=False, help=\
                         'Run an evaluation session. '
                         'Supercedes --session and is the default if nothing is specified. '
-                        'Implies --db.')
+                        'Implies --save.')
     parser.add_argument('--kdma_training', action='store_true', default=False,
                         help='Put the server in training mode in which it shows the kdma '
                         'association for each action choice. Not supported in eval sessions.')
 
     args = parser.parse_args()
-    use_db = "_db_" if args.db else ""
     if args.session:
         if args.session[0] not in ['soartech', 'adept', 'eval']:
             parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
@@ -33,7 +32,7 @@ def main():
     if args.kdma_training and session_type == 'eval':
             parser.error("Training mode is not supported in eval sessions.")
     scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
-    runner = ITMHumanScenarioRunner(use_db, session_type, args.kdma_training, scenario_count)
+    runner = ITMHumanScenarioRunner(session_type, args.save, args.kdma_training, scenario_count)
     runner.run()
 
 if __name__ == "__main__":

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -5,16 +5,13 @@ from itm import ITMHumanScenarioRunner
 def main():
 
     parser = argparse.ArgumentParser(description='Runs Human input simulator.')
-    parser.add_argument('--save', action='store_true', default=False, help=\
-                        'Tell the ADM server to save session history.')
     parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
                         'Specify session type and scenario count. '
                         'Session type can be eval, adept, or soartech. '
                         'If you want to run through all available scenarios without repeating do not use the scenario_count argument')
     parser.add_argument('--eval', action='store_true', default=False, help=\
                         'Run an evaluation session. '
-                        'Supercedes --session and is the default if nothing is specified. '
-                        'Implies --save.')
+                        'Supercedes --session and is the default if nothing is specified. ')
     parser.add_argument('--kdma_training', action='store_true', default=False,
                         help='Put the server in training mode in which it shows the kdma '
                         'association for each action choice. Not supported in eval sessions.')
@@ -32,7 +29,7 @@ def main():
     if args.kdma_training and session_type == 'eval':
             parser.error("Training mode is not supported in eval sessions.")
     scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
-    runner = ITMHumanScenarioRunner(session_type, args.save, args.kdma_training, scenario_count)
+    runner = ITMHumanScenarioRunner(session_type, args.kdma_training, scenario_count)
     runner.run()
 
 if __name__ == "__main__":

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -97,8 +97,6 @@ def main():
     parser = argparse.ArgumentParser(description='Runs ADM scenarios.')
     parser.add_argument('--adm_name', type=str, required=True, 
                         help='Specify the ADM name')
-    parser.add_argument('--save', action='store_true', default=False, help=\
-                        'Tell the ADM server to save session history. Enabled if --eval is set.')
     parser.add_argument('--session', nargs='*', default=[], 
                         metavar=('session_type', 'scenario_count'), 
                         help='Specify session type and scenario count. '
@@ -108,8 +106,7 @@ def main():
                         'argument')
     parser.add_argument('--eval', action='store_true', default=False, 
                         help='Run an evaluation session. '
-                        'Supercedes --session and is the default if nothing is specified. '
-                        'Implies --save.')
+                        'Supercedes --session and is the default if nothing is specified. ')
     parser.add_argument('--kdma_training', action='store_true', default=False,
                         help='Put the server in training mode in which it shows the kdma '
                         'association for each action choice. Not supported in eval sessions.')
@@ -154,7 +151,7 @@ def main():
             )
         else:
             session_id = itm.start_session(
-                adm_name=args.adm_name + ("_save_" if args.save else ""),
+                adm_name=args.adm_name,
                 session_type=session_type,
                 max_scenarios=scenario_count,
                 kdma_training=args.kdma_training

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -97,6 +97,8 @@ def main():
     parser = argparse.ArgumentParser(description='Runs ADM scenarios.')
     parser.add_argument('--adm_name', type=str, required=True, 
                         help='Specify the ADM name')
+    parser.add_argument('--save', action='store_true', default=False, help=\
+                        'Tell the ADM server to save session history. Enabled if --eval is set.')
     parser.add_argument('--session', nargs='*', default=[], 
                         metavar=('session_type', 'scenario_count'), 
                         help='Specify session type and scenario count. '
@@ -107,7 +109,7 @@ def main():
     parser.add_argument('--eval', action='store_true', default=False, 
                         help='Run an evaluation session. '
                         'Supercedes --session and is the default if nothing is specified. '
-                        'Implies --db.')
+                        'Implies --save.')
     parser.add_argument('--kdma_training', action='store_true', default=False,
                         help='Put the server in training mode in which it shows the kdma '
                         'association for each action choice. Not supported in eval sessions.')
@@ -152,7 +154,7 @@ def main():
             )
         else:
             session_id = itm.start_session(
-                adm_name=args.adm_name,
+                adm_name=args.adm_name + ("_save_" if args.save else ""),
                 session_type=session_type,
                 max_scenarios=scenario_count,
                 kdma_training=args.kdma_training


### PR DESCRIPTION
* Removed `--db` option from clients
* ADM name no longer impacts whether history is saved or not.  Previously, if the ADM name ended with `_db_`, then that would tell the server to save to the DB.
* Cleaned up command-line interface, its documentation, and internal runner classes.

To test:  run both the bbn/adept and soartech TA1 servers, and run our clients with training mode toggled off, then toggled on, and ensure that the ADM server is creating new TA1 sessions at the appropriate times (e.g., once at session start when in training mode, and after every scenario when not in training mode).  Make sure `ta1_integration` is set to `True` in the server. 
 Remember that you can specify a number of scenarios to run as part of the `--session` switch.  Here are a few things to try:
-  `python itm_minimal_runner.py --adm_name my_adm1 --session soartech 3 --kdma_training`
-  `python itm_minimal_runner.py --adm_name my_adm2 --session soartech 3`
-  `python itm_minimal_runner.py --adm_name my_adm3 --session adept 3 --kdma_training`
-  `python itm_minimal_runner.py --adm_name my_adm3 --session adept 3`
-  `python itm_minimal_runner.py --adm_name my_adm  --eval`

**NOTE**: if we like the ADM name telling the server whether or not to save history, then we can back out (or reverse) the last commit from both client and server.  Note that doing so introduces a bug where if the client crashes and you restart with the same ADM name, whether you requested logging or not is persistent from the previous session, even if you changed the setting in the re-launch.