### PR TITLE
Add support for scenario selection on the client ADM command lines

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -102,7 +102,7 @@ except ApiException as e:
 # create an instance of the API class
 api_instance = swagger_client.ItmTa2EvalApi(swagger_client.ApiClient(configuration))
 session_id = 'session_id_example' # str | a unique session_id, as returned by /ta2/startSession
-scenario_id = 'scenario_id_example' # str | a scenario id to start, used internally by TA3 (optional)
+scenario_id = 'scenario_id_example' # str | the scenario id to run; incompatible with /ta2/startSession's max_scenarios parameter (optional)
 
 try:
     # Get the next scenario

--- a/docs/ItmTa2EvalApi.md
+++ b/docs/ItmTa2EvalApi.md
@@ -230,7 +230,7 @@ from pprint import pprint
 # create an instance of the API class
 api_instance = swagger_client.ItmTa2EvalApi()
 session_id = 'session_id_example' # str | a unique session_id, as returned by /ta2/startSession
-scenario_id = 'scenario_id_example' # str | a scenario id to start, used internally by TA3 (optional)
+scenario_id = 'scenario_id_example' # str | the scenario id to run; incompatible with /ta2/startSession's max_scenarios parameter (optional)
 
 try:
     # Get the next scenario
@@ -245,7 +245,7 @@ except ApiException as e:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **session_id** | **str**| a unique session_id, as returned by /ta2/startSession | 
- **scenario_id** | **str**| a scenario id to start, used internally by TA3 | [optional] 
+ **scenario_id** | **str**| the scenario id to run; incompatible with /ta2/startSession&#x27;s max_scenarios parameter | [optional] 
 
 ### Return type
 

--- a/itm/itm_adm_scenario_runner.py
+++ b/itm/itm_adm_scenario_runner.py
@@ -66,13 +66,14 @@ class ADMKnowledge:
 
 class ADMScenarioRunner(ScenarioRunner):
 
-    def __init__(self, session_type, max_scenarios=0):
+    def __init__(self, session_type, max_scenarios=0, scenario_id=None):
         super().__init__()
         self.session_id = None
         self.adm_name = "ITM ADM"
         self.eval_mode = session_type == 'eval'
         self.adm_knowledge: ADMKnowledge = None
         self.session_type = session_type
+        self.custom_scenario_id = scenario_id
         self.max_scenarios = max_scenarios
         self.scenarios_run = 0
         self.total_actions_taken = 0
@@ -132,7 +133,11 @@ class ADMScenarioRunner(ScenarioRunner):
 
     def retrieve_scenario(self):
         self.adm_knowledge = ADMKnowledge() 
-        scenario: Scenario = self.itm.start_scenario(self.session_id)
+        scenario: Scenario
+        if self.custom_scenario_id:
+            scenario = self.itm.start_scenario(session_id=self.session_id, scenario_id=self.custom_scenario_id)
+        else:
+            scenario = self.itm.start_scenario(session_id=self.session_id)
         if scenario.session_complete:
             return True
         self.set_scenario(scenario)

--- a/itm_adm_mock.py
+++ b/itm_adm_mock.py
@@ -9,9 +9,12 @@ def main():
                         'If you want to run through all available scenarios without repeating do not use the scenario_count argument')
     parser.add_argument('--eval', action='store_true', default=False, help=\
                         'Run an eval session')
+    parser.add_argument('--scenario', type=str,
+                        help='Specify a scenario_id to run. Incompatible with scenario_count '
+                        'and --eval')
 
     args = parser.parse_args()
-
+    scenario_id = args.scenario
     if args.session:
         if args.session[0] not in ['soartech', 'adept', 'eval']:
             parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
@@ -21,9 +24,16 @@ def main():
         session_type = 'eval'
     if args.eval:
         session_type = 'eval'
+    if session_type == 'eval' and scenario_id:
+        parser.error("Specifying a scenario_id is not supported in eval sessions.")
     scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
+    if scenario_count > 0 and scenario_id:
+        parser.error("Specifying a scenario_id is incompatible with specifying a scenario_count.")
 
-    adm = ADMScenarioRunner(session_type, scenario_count)
+    if scenario_id:
+        adm = ADMScenarioRunner(session_type, scenario_count, scenario_id)
+    else:
+        adm = ADMScenarioRunner(session_type, scenario_count)
     adm.run()
 
 if __name__ == "__main__":

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -100,7 +100,7 @@ paths:
             type: string
         - name: scenario_id
           in: query
-          description: "a scenario id to start, used internally by TA3"
+          description: "the scenario id to run; incompatible with /ta2/startSession's max_scenarios parameter"
           required: false
           style: form
           explode: true
@@ -116,9 +116,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Scenario"
         "400":
-          description: Invalid Session ID or there is already an active scenario
-        "403":
-          description: Specifying a scenario ID is unauthorized
+          description: Invalid Session ID, there is already an active scenario, or scenario_id was specified with max_scenarios
         "404":
           description: Scenario ID not found
         "500":
@@ -128,6 +126,8 @@ paths:
               schema:
                 type: string
                 x-content-type: text/plain
+        "503":
+          description: Could not communicate with TA1 server
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
   /ta2/getAlignmentTarget:
     get:
@@ -198,7 +198,7 @@ paths:
             type: string
       responses:
         "200":
-          description: Successful Response
+          description: Successful Response; if server is configured to run without TA1, then session alignment will be empty/None/null.
           content:
             application/json:
               schema:
@@ -214,6 +214,8 @@ paths:
               schema:
                 type: string
                 x-content-type: text/plain
+        "503":
+          description: Could not get session alignment from TA1
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
   /ta2/{scenario_id}/getState:
     get:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -812,7 +812,7 @@ components:
           $ref: "#/components/schemas/BreathingLevelEnum"
         heart_rate:
           $ref: "#/components/schemas/HeartRateEnum"
-        Spo2:
+        spo2:
           type: number
           format: float
           description: blood oxygen level (percentage)

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -455,7 +455,7 @@ class ItmTa2EvalApi(object):
 
         :param async_req bool
         :param str session_id: a unique session_id, as returned by /ta2/startSession (required)
-        :param str scenario_id: a scenario id to start, used internally by TA3
+        :param str scenario_id: the scenario id to run; incompatible with /ta2/startSession's max_scenarios parameter
         :return: Scenario
                  If the method is called asynchronously,
                  returns the request thread.
@@ -478,7 +478,7 @@ class ItmTa2EvalApi(object):
 
         :param async_req bool
         :param str session_id: a unique session_id, as returned by /ta2/startSession (required)
-        :param str scenario_id: a scenario id to start, used internally by TA3
+        :param str scenario_id: the scenario id to run; incompatible with /ta2/startSession's max_scenarios parameter
         :return: Scenario
                  If the method is called asynchronously,
                  returns the request thread.

--- a/swagger_client/models/vitals.py
+++ b/swagger_client/models/vitals.py
@@ -44,7 +44,7 @@ class Vitals(object):
         'mental_status': 'mental_status',
         'breathing': 'breathing',
         'heart_rate': 'heart_rate',
-        'spo2': 'Spo2'
+        'spo2': 'spo2'
     }
 
     def __init__(self, conscious=None, avpu=None, ambulatory=None, mental_status=None, breathing=None, heart_rate=None, spo2=None):  # noqa: E501


### PR DESCRIPTION
Run against [server branch ITM-186](https://github.com/NextCenturyCorporation/itm-evaluation-server/tree/ITM-186).

To test, try using the new `--scenario` option with various other options, specifying valid (and invalid) eval and training scenarios.