### PR TITLE
ITM-233: Support persistent characters

### DIFF
--- a/docs/Scene.md
+++ b/docs/Scene.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **index** | **int** | The order the scene appears in the scenario | 
 **state** | [**State**](State.md) |  | [optional] 
 **end_scene_allowed** | **bool** | Whether ADMs can explicitly end the scene | 
+**persist_characters** | **bool** | Whether characters should persist from the previous scene | [optional] 
 **probe_config** | [**list[ProbeConfig]**](ProbeConfig.md) | TA1-provided probe configuration, ignored by TA3 | [optional] 
 **tagging** | [**Tagging**](Tagging.md) |  | [optional] 
 **action_mapping** | [**list[ActionMapping]**](ActionMapping.md) | List of actions with details of how those actions map to probe responses | 

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -191,12 +191,16 @@ def main():
             print(f'Scenario name: {scenario.name}')
             alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id) if not args.kdma_training else None
             state: State = scenario.state
+            if state and state.characters:
+                print(state.characters)
             while not state.scenario_complete:
                 actions: List[Action] = itm.get_available_actions(session_id=session_id, scenario_id=scenario.id)
                 action = get_next_action(scenario, state, alignment_target, actions, paths, action_path_index, path_index)
                 print(f'Action type: {action.action_type}; Character ID: {action.character_id}')
                 action_path_index+=1
                 state = itm.take_action(session_id=session_id, body=action)
+                if state and state.characters:
+                    print(state.characters)
                 if args.kdma_training:
                     try:
                         # A TA2 performer would probably want to get alignment target ids from configuration or command-line.

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -97,7 +97,7 @@ def get_random_supply(state: State):
 
 def get_random_character_id(state: State):
     characters : List[Character] = state.characters
-    index = random.randint(0, len(characters) - 1)
+    index = random.randint(0, len(characters) - 1) if len(characters) > 1 else 0
     return characters[index].id
 
 def get_random_evac_id(state: State):
@@ -192,7 +192,9 @@ def main():
             alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id) if not args.kdma_training else None
             state: State = scenario.state
             if state and state.characters:
-                print(state.characters)
+                for character in state.characters:
+                    print(f"character id {character.id} with name {character.name}")
+                    print(character)
             while not state.scenario_complete:
                 actions: List[Action] = itm.get_available_actions(session_id=session_id, scenario_id=scenario.id)
                 action = get_next_action(scenario, state, alignment_target, actions, paths, action_path_index, path_index)
@@ -200,7 +202,9 @@ def main():
                 action_path_index+=1
                 state = itm.take_action(session_id=session_id, body=action)
                 if state and state.characters:
-                    print(state.characters)
+                    for character in state.characters:
+                        print(f"character id {character.id} with name {character.name}")
+                        print(character)
                 if args.kdma_training:
                     try:
                         # A TA2 performer would probably want to get alignment target ids from configuration or command-line.

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -191,20 +191,12 @@ def main():
             print(f'Scenario name: {scenario.name}')
             alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id) if not args.kdma_training else None
             state: State = scenario.state
-            if state and state.characters:
-                for character in state.characters:
-                    print(f"character id {character.id} with name {character.name}")
-                    print(character)
             while not state.scenario_complete:
                 actions: List[Action] = itm.get_available_actions(session_id=session_id, scenario_id=scenario.id)
                 action = get_next_action(scenario, state, alignment_target, actions, paths, action_path_index, path_index)
                 print(f'Action type: {action.action_type}; Character ID: {action.character_id}')
                 action_path_index+=1
                 state = itm.take_action(session_id=session_id, body=action)
-                if state and state.characters:
-                    for character in state.characters:
-                        print(f"character id {character.id} with name {character.name}")
-                        print(character)
                 if args.kdma_training:
                     try:
                         # A TA2 performer would probably want to get alignment target ids from configuration or command-line.

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -854,6 +854,9 @@ components:
         end_scene_allowed:
           type: boolean
           description: Whether ADMs can explicitly end the scene
+        persist_characters:
+          type: boolean
+          description: Whether characters should persist from the previous scene
         probe_config:
           description: TA1-provided probe configuration, ignored by TA3
           type: array

--- a/swagger_client/models/scene.py
+++ b/swagger_client/models/scene.py
@@ -31,6 +31,7 @@ class Scene(object):
         'index': 'int',
         'state': 'State',
         'end_scene_allowed': 'bool',
+        'persist_characters': 'bool',
         'probe_config': 'list[ProbeConfig]',
         'tagging': 'Tagging',
         'action_mapping': 'list[ActionMapping]',
@@ -43,6 +44,7 @@ class Scene(object):
         'index': 'index',
         'state': 'state',
         'end_scene_allowed': 'end_scene_allowed',
+        'persist_characters': 'persist_characters',
         'probe_config': 'probe_config',
         'tagging': 'tagging',
         'action_mapping': 'action_mapping',
@@ -51,11 +53,12 @@ class Scene(object):
         'transitions': 'transitions'
     }
 
-    def __init__(self, index=None, state=None, end_scene_allowed=None, probe_config=None, tagging=None, action_mapping=None, restricted_actions=None, transition_semantics=None, transitions=None):  # noqa: E501
+    def __init__(self, index=None, state=None, end_scene_allowed=None, persist_characters=None, probe_config=None, tagging=None, action_mapping=None, restricted_actions=None, transition_semantics=None, transitions=None):  # noqa: E501
         """Scene - a model defined in Swagger"""  # noqa: E501
         self._index = None
         self._state = None
         self._end_scene_allowed = None
+        self._persist_characters = None
         self._probe_config = None
         self._tagging = None
         self._action_mapping = None
@@ -67,6 +70,8 @@ class Scene(object):
         if state is not None:
             self.state = state
         self.end_scene_allowed = end_scene_allowed
+        if persist_characters is not None:
+            self.persist_characters = persist_characters
         if probe_config is not None:
             self.probe_config = probe_config
         if tagging is not None:
@@ -149,6 +154,29 @@ class Scene(object):
             raise ValueError("Invalid value for `end_scene_allowed`, must not be `None`")  # noqa: E501
 
         self._end_scene_allowed = end_scene_allowed
+
+    @property
+    def persist_characters(self):
+        """Gets the persist_characters of this Scene.  # noqa: E501
+
+        Whether characters should persist from the previous scene  # noqa: E501
+
+        :return: The persist_characters of this Scene.  # noqa: E501
+        :rtype: bool
+        """
+        return self._persist_characters
+
+    @persist_characters.setter
+    def persist_characters(self, persist_characters):
+        """Sets the persist_characters of this Scene.
+
+        Whether characters should persist from the previous scene  # noqa: E501
+
+        :param persist_characters: The persist_characters of this Scene.  # noqa: E501
+        :type: bool
+        """
+
+        self._persist_characters = persist_characters
 
     @property
     def probe_config(self):


### PR DESCRIPTION
* Added `persist_characters` to `Scene` model object
* Fixed bug in client ADM
* Added temporary logging to assist reviewers.

To test, pull the [ITM-233 feature branch](https://github.com/NextCenturyCorporation/itm-evaluation-server/tree/ITM-233) from the server, start the server, then run:
- `python itm_minimal_runner.py --adm_name test --session adept --scenario test-1`

Check the client logging to ensure that after the first action/scene change, Mike character is updated to the new version, the Civilian persists, and the new characters (Katie and Bob) are added.  After the `MOVE_TO_EVAC`, the only character should be Luke, then after a `DIRECT_MOBILE_CHARACTERS`, Luke persists (even though no characters are specified in the scene).

And feel free to play around and test other scenarios/combinations.