### PR TITLE
ITM-242:  Updated human ADM sim

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,32 +57,33 @@ options:
   --adm_name ADM_NAME        Specify the ADM name
   --adm_profile ADM_PROFILE  Specify the ADM profile in terms of its alignment strategy  --session [session_type [scenario_count ...]]
                              Specify session type and scenario count. Session type can be test, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument
+  --session [session_type [scenario_count ...]]
+                             Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
+  --scenario SCENARIO_ID     Runs only the specified scenario. Incompatible with scenario_count and --eval.
   --eval                     Run an evaluation session. Supercedes --session and is the default if nothing is specified.
   --kdma_training            Put the server in training mode in which it shows the kdma association for each action choice.
                              Not supported in eval sessions.
-  --scenario SCENARIO_ID     Runs only the specified scenario. Incompatible with scenario_count and --eval.
 ```
- 
-### Running the Human input simulator
 
-**NOTE**: The human input simulator has not been updated for the metrics evaluation so it is currently unusable.
+### Running the Human input simulator
 
 The Human input simulator is used for testing specific action/parameter sequences or for otherwise simulating a human DM.
 
 Inside the root directory, run `itm_human_input.py`:
 
 ```
-usage: itm_human_input.py [-h] [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]
+usage: itm_human_input.py [-h] [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]  [--scenario SCENARIO_ID]
 
 Runs Human input simulator.
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help              Show this help message and exit
   --session [session_type [scenario_count ...]]
-                        Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
-  --eval                Run an evaluation session. Supercedes --session and is the default if nothing is specified.
-  --kdma_training       Put the server in training mode in which it shows the kdma association for each action choice.
-                        Not supported in eval sessions.
+                          Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
+  --eval                  Run an evaluation session. Supercedes --session and is the default if nothing is specified.
+  --kdma_training         Put the server in training mode in which it shows the kdma association for each action choice.
+                          Not supported in eval sessions.
+  --scenario SCENARIO_ID  Runs only the specified scenario. Incompatible with scenario_count and --eval.
 ```
 
 ### Available Actions

--- a/README.md
+++ b/README.md
@@ -47,22 +47,21 @@ pip3 install -r requirements.txt
  Run `itm_minimal_runner.py` in the root directory:
 
 ```
-usage: itm_minimal_runner.py [-h] --adm_name ADM_NAME [--adm_profile ADM_PROFILE] [--session [session_type [scenario_count ...]]]
-                             [--eval] [--kdma_training] [--scenario SCENARIO_ID]
+usage: itm_minimal_runner.py [-h] --name adm_name [--profile adm_profile] --session session_type [--count scenario_count]
+                             [--training] [--scenario scenario_id]
 
-Runs ADM scenarios.
+Runs ADM simulator.
 
 options:
-  -h, --help                 Show this help message and exit
-  --adm_name ADM_NAME        Specify the ADM name
-  --adm_profile ADM_PROFILE  Specify the ADM profile in terms of its alignment strategy  --session [session_type [scenario_count ...]]
-                             Specify session type and scenario count. Session type can be test, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument
-  --session [session_type [scenario_count ...]]
-                             Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
-  --scenario SCENARIO_ID     Runs only the specified scenario. Incompatible with scenario_count and --eval.
-  --eval                     Run an evaluation session. Supercedes --session and is the default if nothing is specified.
-  --kdma_training            Put the server in training mode in which it shows the kdma association for each action choice.
-                             Not supported in eval sessions.
+  -h, --help              Show this help message and exit
+  --name adm_name         Specify the ADM name
+  --profile adm_profile   Specify the ADM profile in terms of its alignment strategy
+  --session session_type  Specify session type. Session type must be `eval`, `adept`, or `soartech`.
+  --count scenario_count  Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
+                          supported in `eval` sessions.
+  --training              Put the server in training mode in which it returns the KDMA association for each action choice. Not supported
+                          in `eval` sessions.
+  --scenario scenario_id  Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
 ```
 
 ### Running the Human input simulator
@@ -72,18 +71,18 @@ The Human input simulator is used for testing specific action/parameter sequence
 Inside the root directory, run `itm_human_input.py`:
 
 ```
-usage: itm_human_input.py [-h] [--session [session_type [scenario_count ...]]] [--eval] [--kdma_training]  [--scenario SCENARIO_ID]
+usage: itm_human_input.py [-h] --session session_type [--count scenario_count] [--training] [--scenario scenario_id]
 
 Runs Human input simulator.
 
 options:
   -h, --help              Show this help message and exit
-  --session [session_type [scenario_count ...]]
-                          Specify session type and scenario count. Session type can be eval, adept, or soartech. If you want to run through all available scenarios without repeating do not use the scenario_count argument. Default: eval
-  --eval                  Run an evaluation session. Supercedes --session and is the default if nothing is specified.
-  --kdma_training         Put the server in training mode in which it shows the kdma association for each action choice.
-                          Not supported in eval sessions.
-  --scenario SCENARIO_ID  Runs only the specified scenario. Incompatible with scenario_count and --eval.
+  --session session_type  Specify session type. Session type must be `eval`, `adept`, or `soartech`.
+  --count scenario_count  Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
+                          supported in `eval` sessions.
+  --training              Put the server in training mode in which it returns the KDMA association for each action choice. Not supported
+                          in `eval` sessions.
+  --scenario scenario_id  Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
 ```
 
 ### Available Actions

--- a/docs/Conditions.md
+++ b/docs/Conditions.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **elapsed_time_lt** | **int** | True if the scenario elapsed time (in seconds) is less than the specified value | [optional] 
 **elapsed_time_gt** | **int** | True if the scenario elapsed time (in seconds) is greater than the specified value | [optional] 
-**actions** | **list[list[str]]** | True if the any of the specified lists of actions have been taken; multiple action ID lists have \&quot;or\&quot; semantics; multiple action IDs within a list have \&quot;and\&quot; semantics | [optional] 
+**actions** | **list[list[str]]** | True if any of the specified lists of actions have been taken; multiple action ID lists have \&quot;or\&quot; semantics; multiple action IDs within a list have \&quot;and\&quot; semantics | [optional] 
 **probes** | **list[str]** | True if the specified list of probe_ids have been answered | [optional] 
 **probe_responses** | **list[str]** | True if the specified list of probe responses (choice) have been sent | [optional] 
 **character_vitals** | [**list[ConditionsCharacterVitals]**](ConditionsCharacterVitals.md) | True if the specified list of vitals values have been met for the specified character_id | [optional] 

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -23,10 +23,10 @@ class TagTypes(Enum):
     IMMEDIATE = "immediate (i)"
     EXPECTANT = "expectant (e)"
 
-ACTIONS_WITHOUT_CHARACTERS = ["DIRECT_MOBILE_CHARACTERS", "END_SCENE", "SITREP"]
+ACTIONS_WITHOUT_CHARACTERS = ["DIRECT_MOBILE_CHARACTERS", "END_SCENE", "SEARCH", "SITREP"]
 
 class ITMHumanScenarioRunner(ScenarioRunner):
-    def __init__(self, session_type, kdma_training=False, max_scenarios=-1):
+    def __init__(self, session_type, kdma_training=False, max_scenarios=-1, scenario_id=None):
         super().__init__()
         self.username = session_type + " ITM Human"
         self.session_type = session_type
@@ -35,12 +35,14 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             self.max_scenarios = max_scenarios
         else:
             self.max_scenarios = None
+        self.custom_scenario_id = scenario_id
         self.scenario_complete = False
         self.session_complete = False
         self.session_id = None
         self.scenario_id = None
         self.characters = {}
         self.medical_supplies = {}
+        self.aid_delays = []
         self.available_actions = None
         self.actions_are_current = False
         self.current_probe_id = ''
@@ -152,14 +154,33 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             return self.prompt_action()
         return action
 
+    def prompt_evac_id(self) -> Action:
+        evac_input = input(
+            f"Enter Evac ID by number from the list:\n"
+            f"  {[f'({i + 1}, aid_delay={aid_delay})' for i, aid_delay in enumerate(self.aid_delays)]}: "
+        )
+        try:
+            evac_index = int(evac_input) - 1
+            evac_id = None
+            for index, aid_delay in enumerate(self.aid_delays):
+                if index == evac_index:
+                    evac_id = aid_delay.id
+                    break
+        except ValueError:
+            return self.prompt_evac_id()
+        if evac_id is None:
+            return self.prompt_evac_id()
+        return evac_id
+
     def start_scenario_operation(self):
-        if self.session_id == None:
+        if self.session_id is None:
             return "No active session; please start a session first."
         if self.scenario_id == None:
-            response: Scenario = self.itm.start_scenario(self.session_id)
+            response: Scenario = \
+                self.itm.start_scenario(session_id=self.session_id, scenario_id=self.custom_scenario_id if self.custom_scenario_id else None)
             self.current_probe_answered = False
             self.current_probe_id = ''
-            if response.session_complete == False:
+            if not response.session_complete:
                 self.scenario_id = response.id
                 self.scenario = response
                 state: State = response.state
@@ -172,8 +193,8 @@ class ITMHumanScenarioRunner(ScenarioRunner):
         return response
 
     def start_session_operation(self, username):
-        if self.session_id == None:
-            if self.max_scenarios == None:
+        if self.session_id is None:
+            if self.max_scenarios is None:
                 self.session_id = self.itm.start_session(username, self.session_type, kdma_training=self.kdma_training)
             else:
                 self.session_id = self.itm.start_session(username, self.session_type, kdma_training=self.kdma_training, max_scenarios=self.max_scenarios)
@@ -185,16 +206,16 @@ class ITMHumanScenarioRunner(ScenarioRunner):
     def get_alignment_target_operation(self):
         if self.kdma_training:
             return "Getting alignment target is not supported in training mode."
-        if self.session_id == None:
+        if self.session_id is None:
             return "No active session; please start a session first."
-        if self.scenario_id == None:
+        if self.scenario_id is None:
             return "No active scenario; please start a scenario first."
         return self.itm.get_alignment_target(self.session_id, self.scenario_id)
 
     def get_session_alignment_operation(self):
-        if self.session_id == None:
+        if self.session_id is None:
             return "No active session; please start a session first."
-        if self.scenario_id == None:
+        if self.scenario_id is None:
             return "No active scenario; please start a scenario first."
         if self.kdma_training == False:
             return "Session alignment can only be requested during a training session."
@@ -207,27 +228,27 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             return None
 
     def get_scenario_state_operation(self):
-        if self.session_id == None:
+        if self.session_id is None:
             return "No active session; please start a session first."
-        if self.scenario_id == None:
+        if self.scenario_id is None:
             return "No active scenario; please start a scenario first."
         response = self.itm.get_scenario_state(self.session_id, self.scenario_id)
         self.medical_supplies = response.supplies
         return response
 
     def get_available_actions_operation(self):
-        if self.session_id == None:
+        if self.session_id is None:
             return "No active session; please start a session first."
-        if self.scenario_id == None:
+        if self.scenario_id is None:
             return "No active scenario; please start a scenario first."
         self.available_actions = self.itm.get_available_actions(self.session_id, self.scenario_id)
         self.actions_are_current = True
         return self.available_actions
 
     def take_action_operation(self):
-        if self.session_id == None:
+        if self.session_id is None:
             return "No active session; please start a session first."
-        if self.scenario_id == None:
+        if self.scenario_id is None:
             return "No active scenario; please start a scenario first."
         if not self.actions_are_current:
             return f"Call {self.get_full_string_and_shortcut(CommandOption.GET_AVAILABLE_ACTIONS)[0]} first."
@@ -244,9 +265,9 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             if action.parameters is None:
                 action.parameters = {"location": self.prompt_location(), "treatment": self.prompt_treatment()}
             else:
-                if not action.parameters['location'] or action.parameters["location"] is None:
+                if not action.parameters.get('location'):
                     action.parameters["location"] = self.prompt_location()
-                if not action.parameters['treatment'] or action.parameters["treatment"] is None:
+                if not action.parameters.get('treatment'):
                     action.parameters["treatment"] = self.prompt_treatment()
         elif action.action_type == ActionTypeEnum.SITREP:
             if action.character_id is None:
@@ -254,6 +275,9 @@ class ITMHumanScenarioRunner(ScenarioRunner):
         elif action.action_type == ActionTypeEnum.TAG_CHARACTER:
             if action.parameters is None:
                 action.parameters = {"category": self.prompt_tagType()}
+        elif action.action_type == ActionTypeEnum.MOVE_TO_EVAC:
+            if action.parameters is None:
+                action.parameters = {"evac_id": self.prompt_evac_id()}
 
         # Prompt for (optional) justification
         action.justification = self.prompt_justification()
@@ -299,6 +323,9 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             print("Quitting session-- server will not save history for current scenario if it was enabled.")
         elif isinstance(response, State):
             self.medical_supplies = response.supplies
+            self.characters = response.characters
+            if response.environment.decision_environment:
+                self.aid_delays = response.environment.decision_environment.aid_delay
             if response.scenario_complete == True:
                 self.scenario_complete = True
                 self.scenario_id = None

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -112,6 +112,8 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             medical_supply = self.medical_supplies[medical_supply_index].type
         except ValueError:
             return self.prompt_treatment()
+        except IndexError:
+            return self.prompt_treatment()
         return medical_supply
 
     def prompt_justification(self):

--- a/itm_adm_mock.py
+++ b/itm_adm_mock.py
@@ -2,40 +2,46 @@ import argparse
 from itm import ADMScenarioRunner
 
 def main():
-    parser = argparse.ArgumentParser(description='Runs ADM scenarios.')
-    parser.add_argument('--adm_profile', type=str, required=False, 
+    parser = argparse.ArgumentParser(description='Runs ADM simulator.')
+    parser.add_argument('--profile', metavar='adm_profile', required=False, 
                         help='Specify the ADM profile in terms of its alignment strategy')
-    parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
-                        'Specify session type and scenario count. '
-                        'Session type can be eval, adept, or soartech. '
-                        'If you want to run through all available scenarios without repeating do not use the scenario_count argument')
-    parser.add_argument('--eval', action='store_true', default=False, help=\
-                        'Run an eval session')
-    parser.add_argument('--scenario', type=str,
-                        help='Specify a scenario_id to run. Incompatible with scenario_count '
-                        'and --eval')
+    parser.add_argument('--session', required=True, metavar='session_type', help=\
+                        'Specify session type. Session type must be `eval`, `adept`, or `soartech`. ')
+    parser.add_argument('--count', type=int, metavar='scenario_count', help=\
+                        'Run the specified number of scenarios. Otherwise, will run scenarios in '
+                        'accordance with server defaults. Not supported in `eval` sessions.')
+    parser.add_argument('--scenario', type=str, metavar='scenario_id',
+                        help='Specify a scenario_id to run. Incompatible with count parameter '
+                        'and `eval` sessions.')
 
     args = parser.parse_args()
     scenario_id = args.scenario
+    scenario_count = args.count
     if args.session:
-        if args.session[0] not in ['soartech', 'adept', 'eval']:
+        if args.session not in ['soartech', 'adept', 'eval']:
             parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
         else:
-            session_type = args.session[0]
+            session_type = args.session
+
+    if session_type == 'eval':
+        if scenario_id:
+            parser.error("Specifying a scenario_id is not supported in eval sessions.")
+        if scenario_count is not None:
+            parser.error("Scenario count is not supported in eval sessions.")
+
+    if scenario_count is not None:
+        if scenario_count < 1:
+            parser.error("Scenario count must be a positive integer.")
     else:
-        session_type = 'eval'
-    if args.eval:
-        session_type = 'eval'
-    if session_type == 'eval' and scenario_id:
-        parser.error("Specifying a scenario_id is not supported in eval sessions.")
-    scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
+        scenario_count = 0
+
     if scenario_count > 0 and scenario_id:
-        parser.error("Specifying a scenario_id is incompatible with specifying a scenario_count.")
+        parser.error("--scenario is incompatible with --count.")
 
     if scenario_id:
-        adm = ADMScenarioRunner(session_type, args.adm_profile, scenario_count, scenario_id)
+        adm = ADMScenarioRunner(session_type, args.profile, scenario_count, scenario_id)
     else:
-        adm = ADMScenarioRunner(session_type, args.adm_profile, scenario_count)
+        adm = ADMScenarioRunner(session_type, args.profile, scenario_count)
     adm.run()
 
 if __name__ == "__main__":

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -1,4 +1,3 @@
-import sys
 import argparse
 from itm import ITMHumanScenarioRunner
 
@@ -15,8 +14,12 @@ def main():
     parser.add_argument('--kdma_training', action='store_true', default=False,
                         help='Put the server in training mode in which it shows the kdma '
                         'association for each action choice. Not supported in eval sessions.')
+    parser.add_argument('--scenario', type=str,
+                        help='Specify a scenario_id to run. Incompatible with scenario_count '
+                        'and --eval')
 
     args = parser.parse_args()
+    scenario_id = args.scenario
     if args.session:
         if args.session[0] not in ['soartech', 'adept', 'eval']:
             parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
@@ -26,10 +29,18 @@ def main():
         session_type = 'eval'
     if args.eval:
         session_type = 'eval'
+    if session_type == 'eval' and scenario_id:
+        parser.error("Specifying a scenario_id is not supported in eval sessions.")
     if args.kdma_training and session_type == 'eval':
             parser.error("Training mode is not supported in eval sessions.")
     scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
-    runner = ITMHumanScenarioRunner(session_type, args.kdma_training, scenario_count)
+    if scenario_count > 0 and scenario_id:
+        parser.error("Specifying a scenario_id is incompatible with specifying a scenario_count.")
+
+    if scenario_id:
+        runner = ITMHumanScenarioRunner(session_type, args.kdma_training, scenario_count, scenario_id)
+    else:
+        runner = ITMHumanScenarioRunner(session_type, args.kdma_training, scenario_count)
     runner.run()
 
 if __name__ == "__main__":

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -4,43 +4,48 @@ from itm import ITMHumanScenarioRunner
 def main():
 
     parser = argparse.ArgumentParser(description='Runs Human input simulator.')
-    parser.add_argument('--session', nargs='*', default=[], metavar=('session_type', 'scenario_count'), help=\
-                        'Specify session type and scenario count. '
-                        'Session type can be eval, adept, or soartech. '
-                        'If you want to run through all available scenarios without repeating do not use the scenario_count argument')
-    parser.add_argument('--eval', action='store_true', default=False, help=\
-                        'Run an evaluation session. '
-                        'Supercedes --session and is the default if nothing is specified. ')
-    parser.add_argument('--kdma_training', action='store_true', default=False,
-                        help='Put the server in training mode in which it shows the kdma '
-                        'association for each action choice. Not supported in eval sessions.')
-    parser.add_argument('--scenario', type=str,
-                        help='Specify a scenario_id to run. Incompatible with scenario_count '
-                        'and --eval')
+    parser.add_argument('--session', required=True, metavar='session_type', help=\
+                        'Specify session type. Session type must be `eval`, `adept`, or `soartech`. ')
+    parser.add_argument('--count', type=int, metavar='scenario_count', help=\
+                        'Run the specified number of scenarios. Otherwise, will run scenarios in '
+                        'accordance with server defaults. Not supported in `eval` sessions.')
+    parser.add_argument('--training', action='store_true', default=False,
+                        help='Put the server in training mode in which it returns the KDMA '
+                        'association for each action choice. Not supported in `eval` sessions.')
+    parser.add_argument('--scenario', type=str, metavar='scenario_id',
+                        help='Specify a scenario_id to run. Incompatible with count parameter '
+                        'and `eval` sessions.')
 
     args = parser.parse_args()
     scenario_id = args.scenario
+    scenario_count = args.count
     if args.session:
-        if args.session[0] not in ['soartech', 'adept', 'eval']:
+        if args.session not in ['soartech', 'adept', 'eval']:
             parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
         else:
-            session_type = args.session[0]
-    else:
-        session_type = 'eval'
-    if args.eval:
-        session_type = 'eval'
-    if session_type == 'eval' and scenario_id:
-        parser.error("Specifying a scenario_id is not supported in eval sessions.")
-    if args.kdma_training and session_type == 'eval':
+            session_type = args.session
+
+    if session_type == 'eval':
+        if scenario_id:
+            parser.error("Specifying a scenario_id is not supported in eval sessions.")
+        if args.training:
             parser.error("Training mode is not supported in eval sessions.")
-    scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
+        if scenario_count is not None:
+            parser.error("Scenario count is not supported in eval sessions.")
+
+    if scenario_count is not None:
+        if scenario_count < 1:
+            parser.error("Scenario count must be a positive integer.")
+    else:
+        scenario_count = 0
+
     if scenario_count > 0 and scenario_id:
-        parser.error("Specifying a scenario_id is incompatible with specifying a scenario_count.")
+        parser.error("--scenario is incompatible with --count.")
 
     if scenario_id:
-        runner = ITMHumanScenarioRunner(session_type, args.kdma_training, scenario_count, scenario_id)
+        runner = ITMHumanScenarioRunner(session_type, args.training, scenario_count, scenario_id)
     else:
-        runner = ITMHumanScenarioRunner(session_type, args.kdma_training, scenario_count)
+        runner = ITMHumanScenarioRunner(session_type, args.training, scenario_count)
     runner.run()
 
 if __name__ == "__main__":

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -109,47 +109,48 @@ def get_random_evac_id(state: State):
     return evac_id
 
 def main():
-    parser = argparse.ArgumentParser(description='Runs ADM scenarios.')
-    parser.add_argument('--adm_name', type=str, required=True, 
+    parser = argparse.ArgumentParser(description='Runs ADM simulator.')
+    parser.add_argument('--name', metavar='adm_name', required=True, 
                         help='Specify the ADM name')
-    parser.add_argument('--adm_profile', type=str, required=False, 
+    parser.add_argument('--profile', metavar='adm_profile', required=False, 
                         help='Specify the ADM profile in terms of its alignment strategy')
-    parser.add_argument('--session', nargs='*', default=[], 
-                        metavar=('session_type', 'scenario_count'), 
-                        help='Specify session type and scenario count. '
-                        'Session type can be eval, adept, or soartech. '
-                        'If you want to run through all available scenarios '
-                        'without repeating do not use the scenario_count '
-                        'argument')
-    parser.add_argument('--scenario', type=str,
-                        help='Specify a scenario_id to run. Incompatible with scenario_count '
-                        'and --eval')
-    parser.add_argument('--eval', action='store_true', default=False, 
-                        help='Run an evaluation session. '
-                        'Supercedes --session and is the default if nothing is specified. ')
-    parser.add_argument('--kdma_training', action='store_true', default=False,
-                        help='Put the server in training mode in which it shows the kdma '
-                        'association for each action choice. Not supported in eval sessions.')
+    parser.add_argument('--session', required=True, metavar='session_type', help=\
+                        'Specify session type. Session type must be `eval`, `adept`, or `soartech`. ')
+    parser.add_argument('--count', type=int, metavar='scenario_count', help=\
+                        'Run the specified number of scenarios. Otherwise, will run scenarios in '
+                        'accordance with server defaults. Not supported in `eval` sessions.')
+    parser.add_argument('--training', action='store_true', default=False,
+                        help='Put the server in training mode in which it returns the KDMA '
+                        'association for each action choice. Not supported in `eval` sessions.')
+    parser.add_argument('--scenario', type=str, metavar='scenario_id',
+                        help='Specify a scenario_id to run. Incompatible with count parameter '
+                        'and `eval` sessions.')
 
     args = parser.parse_args()
     scenario_id = args.scenario
+    scenario_count = args.count
     if args.session:
-        if args.session[0] not in ['soartech', 'adept', 'eval']:
+        if args.session not in ['soartech', 'adept', 'eval']:
             parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
         else:
-            session_type = args.session[0]
-    else:
-        session_type = 'eval'
-    if args.eval:
-        session_type = 'eval'
+            session_type = args.session
+
     if session_type == 'eval':
-        if args.kdma_training:
-            parser.error("Training mode is not supported in eval sessions.")
         if scenario_id:
             parser.error("Specifying a scenario_id is not supported in eval sessions.")
-    scenario_count = int(args.session[1]) if len(args.session) > 1 else 0
+        if args.training:
+            parser.error("Training mode is not supported in eval sessions.")
+        if scenario_count is not None:
+            parser.error("Scenario count is not supported in eval sessions.")
+
+    if scenario_count is not None:
+        if scenario_count < 1:
+            parser.error("Scenario count must be a positive integer.")
+    else:
+        scenario_count = 0
+
     if scenario_count > 0 and scenario_id:
-        parser.error("Specifying a scenario_id is incompatible with specifying a scenario_count.")
+        parser.error("--scenario is incompatible with --count.")
 
     config = Configuration()
     PORT = os.getenv('TA3_PORT')
@@ -172,17 +173,17 @@ def main():
 
         if session_type == 'eval':
             session_id = itm.start_session(
-                adm_name=args.adm_name,
-                adm_profile=args.adm_profile,
+                adm_name=args.name,
+                adm_profile=args.profile,
                 session_type='eval'
             )
         else:
             session_id = itm.start_session(
-                adm_name=args.adm_name,
-                adm_profile=args.adm_profile,
+                adm_name=args.name,
+                adm_profile=args.profile,
                 session_type=session_type,
                 max_scenarios=scenario_count,
-                kdma_training=args.kdma_training
+                kdma_training=args.training
             )
         while True:
             scenario: Scenario

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -194,7 +194,8 @@ def main():
             if scenario.session_complete:
                 break
             print(f'Scenario name: {scenario.name}')
-            alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id) if not args.kdma_training else None
+            alignment_target: AlignmentTarget = itm.get_alignment_target(session_id, scenario.id) if not args.training else None
+            print(f'{alignment_target}')
             state: State = scenario.state
             while not state.scenario_complete:
                 actions: List[Action] = itm.get_available_actions(session_id=session_id, scenario_id=scenario.id)
@@ -202,7 +203,7 @@ def main():
                 print(f'Action type: {action.action_type}; Character ID: {action.character_id}')
                 action_path_index+=1
                 state = itm.take_action(session_id=session_id, body=action)
-                if args.kdma_training:
+                if args.training:
                     try:
                         # A TA2 performer would probably want to get alignment target ids from configuration or command-line.
                         target_id = SOARTECH_ALIGNMENT if session_type == 'soartech' else ADEPT_ALIGNMENT
@@ -210,7 +211,7 @@ def main():
                     except Exception as e:
                         # An exception will occur if no probes have been answered yet, so just log this succinctly.
                         print(e)
-            if not args.kdma_training:
+            if not args.training:
                 print(f'{state.unstructured}')
         print(f'Session {session_id} complete')
         path_index+=1

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1005,7 +1005,7 @@ components:
           description: True if the scenario elapsed time (in seconds) is greater than the specified value
           minimum: 5
         actions:
-          description: True if the any of the specified lists of actions have been taken; multiple action ID lists have "or" semantics; multiple action IDs within a list have "and" semantics
+          description: True if any of the specified lists of actions have been taken; multiple action ID lists have "or" semantics; multiple action IDs within a list have "and" semantics
           type: array
           items:
             type: array
@@ -1627,6 +1627,7 @@ components:
         - left side
         - right chest
         - left chest
+        - center chest
         - right wrist
         - left wrist
         - left face

--- a/swagger_client/models/conditions.py
+++ b/swagger_client/models/conditions.py
@@ -122,7 +122,7 @@ class Conditions(object):
     def actions(self):
         """Gets the actions of this Conditions.  # noqa: E501
 
-        True if the any of the specified lists of actions have been taken; multiple action ID lists have \"or\" semantics; multiple action IDs within a list have \"and\" semantics  # noqa: E501
+        True if any of the specified lists of actions have been taken; multiple action ID lists have \"or\" semantics; multiple action IDs within a list have \"and\" semantics  # noqa: E501
 
         :return: The actions of this Conditions.  # noqa: E501
         :rtype: list[list[str]]
@@ -133,7 +133,7 @@ class Conditions(object):
     def actions(self, actions):
         """Sets the actions of this Conditions.
 
-        True if the any of the specified lists of actions have been taken; multiple action ID lists have \"or\" semantics; multiple action IDs within a list have \"and\" semantics  # noqa: E501
+        True if any of the specified lists of actions have been taken; multiple action ID lists have \"or\" semantics; multiple action IDs within a list have \"and\" semantics  # noqa: E501
 
         :param actions: The actions of this Conditions.  # noqa: E501
         :type: list[list[str]]

--- a/swagger_client/models/injury_location_enum.py
+++ b/swagger_client/models/injury_location_enum.py
@@ -44,6 +44,7 @@ class InjuryLocationEnum(object):
     LEFT_SIDE = "left side"
     RIGHT_CHEST = "right chest"
     LEFT_CHEST = "left chest"
+    CENTER_CHEST = "center chest"
     RIGHT_WRIST = "right wrist"
     LEFT_WRIST = "left wrist"
     LEFT_FACE = "left face"


### PR DESCRIPTION
- `SEARCH` doesn't require a character parameter
- Prompt if necessary for `evac_id` in `MOVE_TO_EVAC` action
- Add `scenario_id` parameter to command line (helps testing if nothing else)
- Updated README

To test, invoke the human ADM sim and run through a scenario.  I recommend using `--scenario` option to choose your scenario by ID.  The freeform scenarios offer flexibility, but you also might want to try at least part of a TA1 scenario.  Adept's sub scenario (`MetricsEval.MD6-Submarine`) isn't too long.  You can try with our without TA1 integration.  Also try different command line arguments (including illegal ones) to make sure it's doing the right thing.