### PR TITLE
ITM-409: Remove "conscious" from Vitals

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -113,7 +113,7 @@ except ApiException as e:
 
 # create an instance of the API class
 api_instance = swagger_client.ItmTa2EvalApi(swagger_client.ApiClient(configuration))
-adm_name = 'adm_name_example' # str | A self-assigned ADM name.  Can add authentication later.
+adm_name = 'adm_name_example' # str | A self-assigned ADM name.
 session_type = 'session_type_example' # str | the type of session to start (`eval` or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
 kdma_training = false # bool | whether or not this is a training session with TA2 (optional) (default to false)

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Further details can be found in the ITM Server FAQ below.
   * Reveals discoverable injuries and certain basic vitals for the specified `character_id`.
     * requires `character_id`
 * `DIRECT_MOBILE_CHARACTERS`
-  * Reveals the `ambulatory`, `conscious`, `mental_status`, and `avpu` vitals from conscious, mobile, responsive characters.
+  * Reveals the `ambulatory`, `mental_status`, and `avpu` vitals from mobile, responsive, alert characters.
     * no further requirements
 * `END_SCENE`
   * Equivalent to the ADM choosing "none of the above" available actions.
@@ -129,7 +129,7 @@ Further details can be found in the ITM Server FAQ below.
 ### ITM TA3 Server FAQ
 
 1. What are "certain basic vitals" from the action descriptions above?
-   * Basic vitals include `conscious`, `avpu`, `ambulatory`, `mental_status`, and `breathing`. These are revealed by `SITREP`, `APPLY_TREATMENT`, and all `CHECK_*` actions.
+   * Basic vitals include `avpu`, `ambulatory`, `mental_status`, and `breathing`. These are revealed by `SITREP`, `APPLY_TREATMENT`, and all `CHECK_*` actions.
 2. What is a "scene" and how do I know when a scene has changed?
    * It can be confusing because a scene can mean a few different things:
      * A scene is a narrative construct, where within a scenario a human decision-maker moves between one physical area and another, each with a different set of characters.  The human in the sim literally moves (or is teleported) to a different scene, whereas the ADM gets an updated state with changes to structured and unstructured data, conveying the scene change.

--- a/docs/ActionMapping.md
+++ b/docs/ActionMapping.md
@@ -11,7 +11,7 @@ Name | Type | Description | Notes
 **parameters** | **dict(str, str)** | key-value pairs containing additional [action-specific parameters](https://github.com/NextCenturyCorporation/itm-evaluation-client?tab&#x3D;readme-ov-file#available-actions) | [optional] 
 **probe_id** | **str** | A valid probe_id from the appropriate TA1 | 
 **choice** | **str** | A valid choice for the specified probe_id | 
-**next_scene** | **int** | The next scene in the scenario, by index | [optional] 
+**next_scene** | **str** | The ID of the next scene in the scenario; overrides Scene.next_scene | [optional] 
 **kdma_association** | **dict(str, float)** | KDMA associations for this choice, if provided by TA1 | [optional] 
 **condition_semantics** | [**SemanticTypeEnum**](SemanticTypeEnum.md) |  | [optional] 
 **conditions** | [**Conditions**](Conditions.md) |  | [optional] 

--- a/docs/Conditions.md
+++ b/docs/Conditions.md
@@ -8,8 +8,8 @@ Name | Type | Description | Notes
 **actions** | **list[list[str]]** | True if any of the specified lists of actions have been taken; multiple action ID lists have \&quot;or\&quot; semantics; multiple action IDs within a list have \&quot;and\&quot; semantics | [optional] 
 **probes** | **list[str]** | True if the specified list of probe_ids have been answered | [optional] 
 **probe_responses** | **list[str]** | True if the specified list of probe responses (choice) have been sent | [optional] 
-**character_vitals** | [**list[ConditionsCharacterVitals]**](ConditionsCharacterVitals.md) | True if the specified list of vitals values have been met for the specified character_id | [optional] 
-**supplies** | [**list[Supplies]**](Supplies.md) | True if there are at least the specified quantity of the specified supply types remaining | [optional] 
+**character_vitals** | [**list[ConditionsCharacterVitals]**](ConditionsCharacterVitals.md) | True if the any of the specified collection of vital values have been met for the specified character_id | [optional] 
+**supplies** | [**list[Supplies]**](Supplies.md) | True if any of the specified supplies reach or go below the specified quantity | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/ItmTa2EvalApi.md
+++ b/docs/ItmTa2EvalApi.md
@@ -279,7 +279,7 @@ from pprint import pprint
 
 # create an instance of the API class
 api_instance = swagger_client.ItmTa2EvalApi()
-adm_name = 'adm_name_example' # str | A self-assigned ADM name.  Can add authentication later.
+adm_name = 'adm_name_example' # str | A self-assigned ADM name.
 session_type = 'session_type_example' # str | the type of session to start (`eval` or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
 kdma_training = false # bool | whether or not this is a training session with TA2 (optional) (default to false)
@@ -297,7 +297,7 @@ except ApiException as e:
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **adm_name** | **str**| A self-assigned ADM name.  Can add authentication later. | 
+ **adm_name** | **str**| A self-assigned ADM name. | 
  **session_type** | **str**| the type of session to start (&#x60;eval&#x60; or a TA1 name) | 
  **adm_profile** | **str**| a profile of the ADM in terms of its alignment strategy | [optional] 
  **kdma_training** | **bool**| whether or not this is a training session with TA2 | [optional] [default to false]

--- a/docs/Scenario.md
+++ b/docs/Scenario.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **str** | a globally unique id for the scenario | 
 **name** | **str** | human-readable scenario name, not necessarily unique | 
+**first_scene** | **str** | indicates the first/opening scene ID in the scenario | [optional] 
 **session_complete** | **bool** | set to true if the session is complete; that is, there are no more scenarios | [optional] 
 **state** | [**State**](State.md) |  | [optional] 
 **scenes** | [**list[Scene]**](Scene.md) | A list of specification for all scenes in the scenario | [optional] 

--- a/docs/Scene.md
+++ b/docs/Scene.md
@@ -3,9 +3,9 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**index** | **int** | The order the scene appears in the scenario | 
+**id** | **str** | The scene ID, unique throughout the scenario | 
 **state** | [**State**](State.md) |  | [optional] 
-**final_scene** | **bool** | Whether this is the final scene in the scenario | [optional] 
+**next_scene** | **str** | The ID of the default next scene in the scenario; if empty or missing, then by default this is the last scene. | [optional] 
 **end_scene_allowed** | **bool** | Whether ADMs can explicitly end the scene | 
 **persist_characters** | **bool** | Whether characters should persist from the previous scene | [optional] 
 **probe_config** | [**list[ProbeConfig]**](ProbeConfig.md) | TA1-provided probe configuration, ignored by TA3 | [optional] 

--- a/docs/Vitals.md
+++ b/docs/Vitals.md
@@ -3,7 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**conscious** | **bool** | whether or not the character appears to be conscious | [optional] 
 **avpu** | [**AvpuLevelEnum**](AvpuLevelEnum.md) |  | [optional] 
 **ambulatory** | **bool** | whether or not the character can walk | [optional] 
 **mental_status** | [**MentalStatusEnum**](MentalStatusEnum.md) |  | [optional] 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -24,8 +24,16 @@ paths:
       parameters:
         - name: adm_name
           in: query
-          description: A self-assigned ADM name.  Can add authentication later.
+          description: A self-assigned ADM name.
           required: true
+          style: form
+          explode: true
+          schema:
+            type: string
+        - name: adm_profile
+          in: query
+          description: a profile of the ADM in terms of its alignment strategy
+          required: false
           style: form
           explode: true
           schema:
@@ -39,14 +47,6 @@ paths:
           schema:
             type: string
             example: eval
-        - name: adm_profile
-          in: query
-          description: a profile of the ADM in terms of its alignment strategy
-          required: false
-          style: form
-          explode: true
-          schema:
-            type: string
         - name: kdma_training
           in: query
           description: whether or not this is a training session with TA2
@@ -373,6 +373,9 @@ components:
           type: string
           description: human-readable scenario name, not necessarily unique
           example: IED Explosion
+        first_scene:
+          type: string
+          description: indicates the first/opening scene ID in the scenario
         session_complete:
           type: boolean
           description: "set to true if the session is complete; that is, there are\
@@ -806,9 +809,6 @@ components:
       type: object
       description: Vital levels and other indications of health
       properties:
-        conscious:
-          type: boolean
-          description: whether or not the character appears to be conscious
         avpu:
           $ref: "#/components/schemas/AvpuLevelEnum"
         ambulatory:
@@ -847,21 +847,20 @@ components:
           type: string
     Scene:
       required:
-        - index
+        - id
         - end_scene_allowed
         - action_mapping
       type: object
       description: the specification for a scene in the scenario
       properties:
-        index:
-          type: integer
-          description: The order the scene appears in the scenario
-          minimum: 0
+        id:
+          type: string
+          description: The scene ID, unique throughout the scenario
         state:
           $ref: "#/components/schemas/State"
-        final_scene:
-          type: boolean
-          description: Whether this is the final scene in the scenario
+        next_scene:
+          type: string
+          description: "The ID of the default next scene in the scenario; if empty or missing, then by default this is the last scene."
         end_scene_allowed:
           type: boolean
           description: Whether ADMs can explicitly end the scene
@@ -975,9 +974,8 @@ components:
           type: string
           description: A valid choice for the specified probe_id
         next_scene:
-          type: integer
-          description: The next scene in the scenario, by index
-          minimum: 0
+          type: string
+          description: The ID of the next scene in the scenario; overrides Scene.next_scene
         kdma_association:
           type: object
           additionalProperties:
@@ -1027,13 +1025,13 @@ components:
             - adept-september-demo-probe-1-choice2
         character_vitals:
           type: array
-          description: True if the specified list of vitals values have been met for the specified character_id
+          description: True if the any of the specified collection of vital values have been met for the specified character_id
           items:
             required:
               - character_id
               - vitals
             type: object
-            description: The minimum vitals of the specified character
+            description: True if all vitals values have been met by the specified character_id
             properties:
               character_id:
                 type: string
@@ -1042,7 +1040,7 @@ components:
                 $ref: "#/components/schemas/Vitals"
         supplies:
           type: array
-          description: True if there are at least the specified quantity of the specified supply types remaining
+          description: True if any of the specified supplies reach or go below the specified quantity
           items:
             $ref: "#/components/schemas/Supplies"
           example:
@@ -1656,7 +1654,7 @@ components:
         - treated
     AvpuLevelEnum:
       type: string
-      description: Character level of response.  See [Levels of Response](https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response) for details
+      description: Character level of response; anything but ALERT is considered unconscious.  See [Levels of Response](https://www.firstresponse.org.uk/first-aid-az/3-general/first-aid/79-levels-of-response) for details
       enum:
         - ALERT
         - VOICE

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -553,7 +553,7 @@ class ItmTa2EvalApi(object):
         >>> result = thread.get()
 
         :param async_req bool
-        :param str adm_name: A self-assigned ADM name.  Can add authentication later. (required)
+        :param str adm_name: A self-assigned ADM name. (required)
         :param str session_type: the type of session to start (`eval` or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
         :param bool kdma_training: whether or not this is a training session with TA2
@@ -579,7 +579,7 @@ class ItmTa2EvalApi(object):
         >>> result = thread.get()
 
         :param async_req bool
-        :param str adm_name: A self-assigned ADM name.  Can add authentication later. (required)
+        :param str adm_name: A self-assigned ADM name. (required)
         :param str session_type: the type of session to start (`eval` or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
         :param bool kdma_training: whether or not this is a training session with TA2
@@ -620,10 +620,10 @@ class ItmTa2EvalApi(object):
         query_params = []
         if 'adm_name' in params:
             query_params.append(('adm_name', params['adm_name']))  # noqa: E501
-        if 'session_type' in params:
-            query_params.append(('session_type', params['session_type']))  # noqa: E501
         if 'adm_profile' in params:
             query_params.append(('adm_profile', params['adm_profile']))  # noqa: E501
+        if 'session_type' in params:
+            query_params.append(('session_type', params['session_type']))  # noqa: E501
         if 'kdma_training' in params:
             query_params.append(('kdma_training', params['kdma_training']))  # noqa: E501
         if 'max_scenarios' in params:

--- a/swagger_client/models/action_mapping.py
+++ b/swagger_client/models/action_mapping.py
@@ -36,7 +36,7 @@ class ActionMapping(object):
         'parameters': 'dict(str, str)',
         'probe_id': 'str',
         'choice': 'str',
-        'next_scene': 'int',
+        'next_scene': 'str',
         'kdma_association': 'dict(str, float)',
         'condition_semantics': 'SemanticTypeEnum',
         'conditions': 'Conditions'
@@ -288,10 +288,10 @@ class ActionMapping(object):
     def next_scene(self):
         """Gets the next_scene of this ActionMapping.  # noqa: E501
 
-        The next scene in the scenario, by index  # noqa: E501
+        The ID of the next scene in the scenario; overrides Scene.next_scene  # noqa: E501
 
         :return: The next_scene of this ActionMapping.  # noqa: E501
-        :rtype: int
+        :rtype: str
         """
         return self._next_scene
 
@@ -299,10 +299,10 @@ class ActionMapping(object):
     def next_scene(self, next_scene):
         """Sets the next_scene of this ActionMapping.
 
-        The next scene in the scenario, by index  # noqa: E501
+        The ID of the next scene in the scenario; overrides Scene.next_scene  # noqa: E501
 
         :param next_scene: The next_scene of this ActionMapping.  # noqa: E501
-        :type: int
+        :type: str
         """
 
         self._next_scene = next_scene

--- a/swagger_client/models/conditions.py
+++ b/swagger_client/models/conditions.py
@@ -191,7 +191,7 @@ class Conditions(object):
     def character_vitals(self):
         """Gets the character_vitals of this Conditions.  # noqa: E501
 
-        True if the specified list of vitals values have been met for the specified character_id  # noqa: E501
+        True if the any of the specified collection of vital values have been met for the specified character_id  # noqa: E501
 
         :return: The character_vitals of this Conditions.  # noqa: E501
         :rtype: list[ConditionsCharacterVitals]
@@ -202,7 +202,7 @@ class Conditions(object):
     def character_vitals(self, character_vitals):
         """Sets the character_vitals of this Conditions.
 
-        True if the specified list of vitals values have been met for the specified character_id  # noqa: E501
+        True if the any of the specified collection of vital values have been met for the specified character_id  # noqa: E501
 
         :param character_vitals: The character_vitals of this Conditions.  # noqa: E501
         :type: list[ConditionsCharacterVitals]
@@ -214,7 +214,7 @@ class Conditions(object):
     def supplies(self):
         """Gets the supplies of this Conditions.  # noqa: E501
 
-        True if there are at least the specified quantity of the specified supply types remaining  # noqa: E501
+        True if any of the specified supplies reach or go below the specified quantity  # noqa: E501
 
         :return: The supplies of this Conditions.  # noqa: E501
         :rtype: list[Supplies]
@@ -225,7 +225,7 @@ class Conditions(object):
     def supplies(self, supplies):
         """Sets the supplies of this Conditions.
 
-        True if there are at least the specified quantity of the specified supply types remaining  # noqa: E501
+        True if any of the specified supplies reach or go below the specified quantity  # noqa: E501
 
         :param supplies: The supplies of this Conditions.  # noqa: E501
         :type: list[Supplies]

--- a/swagger_client/models/scenario.py
+++ b/swagger_client/models/scenario.py
@@ -30,6 +30,7 @@ class Scenario(object):
     swagger_types = {
         'id': 'str',
         'name': 'str',
+        'first_scene': 'str',
         'session_complete': 'bool',
         'state': 'State',
         'scenes': 'list[Scene]'
@@ -38,21 +39,25 @@ class Scenario(object):
     attribute_map = {
         'id': 'id',
         'name': 'name',
+        'first_scene': 'first_scene',
         'session_complete': 'session_complete',
         'state': 'state',
         'scenes': 'scenes'
     }
 
-    def __init__(self, id=None, name=None, session_complete=None, state=None, scenes=None):  # noqa: E501
+    def __init__(self, id=None, name=None, first_scene=None, session_complete=None, state=None, scenes=None):  # noqa: E501
         """Scenario - a model defined in Swagger"""  # noqa: E501
         self._id = None
         self._name = None
+        self._first_scene = None
         self._session_complete = None
         self._state = None
         self._scenes = None
         self.discriminator = None
         self.id = id
         self.name = name
+        if first_scene is not None:
+            self.first_scene = first_scene
         if session_complete is not None:
             self.session_complete = session_complete
         if state is not None:
@@ -109,6 +114,29 @@ class Scenario(object):
             raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
 
         self._name = name
+
+    @property
+    def first_scene(self):
+        """Gets the first_scene of this Scenario.  # noqa: E501
+
+        indicates the first/opening scene ID in the scenario  # noqa: E501
+
+        :return: The first_scene of this Scenario.  # noqa: E501
+        :rtype: str
+        """
+        return self._first_scene
+
+    @first_scene.setter
+    def first_scene(self, first_scene):
+        """Sets the first_scene of this Scenario.
+
+        indicates the first/opening scene ID in the scenario  # noqa: E501
+
+        :param first_scene: The first_scene of this Scenario.  # noqa: E501
+        :type: str
+        """
+
+        self._first_scene = first_scene
 
     @property
     def session_complete(self):

--- a/swagger_client/models/scene.py
+++ b/swagger_client/models/scene.py
@@ -28,9 +28,9 @@ class Scene(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'index': 'int',
+        'id': 'str',
         'state': 'State',
-        'final_scene': 'bool',
+        'next_scene': 'str',
         'end_scene_allowed': 'bool',
         'persist_characters': 'bool',
         'probe_config': 'list[ProbeConfig]',
@@ -42,9 +42,9 @@ class Scene(object):
     }
 
     attribute_map = {
-        'index': 'index',
+        'id': 'id',
         'state': 'state',
-        'final_scene': 'final_scene',
+        'next_scene': 'next_scene',
         'end_scene_allowed': 'end_scene_allowed',
         'persist_characters': 'persist_characters',
         'probe_config': 'probe_config',
@@ -55,11 +55,11 @@ class Scene(object):
         'transitions': 'transitions'
     }
 
-    def __init__(self, index=None, state=None, final_scene=None, end_scene_allowed=None, persist_characters=None, probe_config=None, tagging=None, action_mapping=None, restricted_actions=None, transition_semantics=None, transitions=None):  # noqa: E501
+    def __init__(self, id=None, state=None, next_scene=None, end_scene_allowed=None, persist_characters=None, probe_config=None, tagging=None, action_mapping=None, restricted_actions=None, transition_semantics=None, transitions=None):  # noqa: E501
         """Scene - a model defined in Swagger"""  # noqa: E501
-        self._index = None
+        self._id = None
         self._state = None
-        self._final_scene = None
+        self._next_scene = None
         self._end_scene_allowed = None
         self._persist_characters = None
         self._probe_config = None
@@ -69,11 +69,11 @@ class Scene(object):
         self._transition_semantics = None
         self._transitions = None
         self.discriminator = None
-        self.index = index
+        self.id = id
         if state is not None:
             self.state = state
-        if final_scene is not None:
-            self.final_scene = final_scene
+        if next_scene is not None:
+            self.next_scene = next_scene
         self.end_scene_allowed = end_scene_allowed
         if persist_characters is not None:
             self.persist_characters = persist_characters
@@ -90,29 +90,29 @@ class Scene(object):
             self.transitions = transitions
 
     @property
-    def index(self):
-        """Gets the index of this Scene.  # noqa: E501
+    def id(self):
+        """Gets the id of this Scene.  # noqa: E501
 
-        The order the scene appears in the scenario  # noqa: E501
+        The scene ID, unique throughout the scenario  # noqa: E501
 
-        :return: The index of this Scene.  # noqa: E501
-        :rtype: int
+        :return: The id of this Scene.  # noqa: E501
+        :rtype: str
         """
-        return self._index
+        return self._id
 
-    @index.setter
-    def index(self, index):
-        """Sets the index of this Scene.
+    @id.setter
+    def id(self, id):
+        """Sets the id of this Scene.
 
-        The order the scene appears in the scenario  # noqa: E501
+        The scene ID, unique throughout the scenario  # noqa: E501
 
-        :param index: The index of this Scene.  # noqa: E501
-        :type: int
+        :param id: The id of this Scene.  # noqa: E501
+        :type: str
         """
-        if index is None:
-            raise ValueError("Invalid value for `index`, must not be `None`")  # noqa: E501
+        if id is None:
+            raise ValueError("Invalid value for `id`, must not be `None`")  # noqa: E501
 
-        self._index = index
+        self._id = id
 
     @property
     def state(self):
@@ -136,27 +136,27 @@ class Scene(object):
         self._state = state
 
     @property
-    def final_scene(self):
-        """Gets the final_scene of this Scene.  # noqa: E501
+    def next_scene(self):
+        """Gets the next_scene of this Scene.  # noqa: E501
 
-        Whether this is the final scene in the scenario  # noqa: E501
+        The ID of the default next scene in the scenario; if empty or missing, then by default this is the last scene.  # noqa: E501
 
-        :return: The final_scene of this Scene.  # noqa: E501
-        :rtype: bool
+        :return: The next_scene of this Scene.  # noqa: E501
+        :rtype: str
         """
-        return self._final_scene
+        return self._next_scene
 
-    @final_scene.setter
-    def final_scene(self, final_scene):
-        """Sets the final_scene of this Scene.
+    @next_scene.setter
+    def next_scene(self, next_scene):
+        """Sets the next_scene of this Scene.
 
-        Whether this is the final scene in the scenario  # noqa: E501
+        The ID of the default next scene in the scenario; if empty or missing, then by default this is the last scene.  # noqa: E501
 
-        :param final_scene: The final_scene of this Scene.  # noqa: E501
-        :type: bool
+        :param next_scene: The next_scene of this Scene.  # noqa: E501
+        :type: str
         """
 
-        self._final_scene = final_scene
+        self._next_scene = next_scene
 
     @property
     def end_scene_allowed(self):

--- a/swagger_client/models/vitals.py
+++ b/swagger_client/models/vitals.py
@@ -28,7 +28,6 @@ class Vitals(object):
                             and the value is json key in definition.
     """
     swagger_types = {
-        'conscious': 'bool',
         'avpu': 'AvpuLevelEnum',
         'ambulatory': 'bool',
         'mental_status': 'MentalStatusEnum',
@@ -38,7 +37,6 @@ class Vitals(object):
     }
 
     attribute_map = {
-        'conscious': 'conscious',
         'avpu': 'avpu',
         'ambulatory': 'ambulatory',
         'mental_status': 'mental_status',
@@ -47,9 +45,8 @@ class Vitals(object):
         'spo2': 'spo2'
     }
 
-    def __init__(self, conscious=None, avpu=None, ambulatory=None, mental_status=None, breathing=None, heart_rate=None, spo2=None):  # noqa: E501
+    def __init__(self, avpu=None, ambulatory=None, mental_status=None, breathing=None, heart_rate=None, spo2=None):  # noqa: E501
         """Vitals - a model defined in Swagger"""  # noqa: E501
-        self._conscious = None
         self._avpu = None
         self._ambulatory = None
         self._mental_status = None
@@ -57,8 +54,6 @@ class Vitals(object):
         self._heart_rate = None
         self._spo2 = None
         self.discriminator = None
-        if conscious is not None:
-            self.conscious = conscious
         if avpu is not None:
             self.avpu = avpu
         if ambulatory is not None:
@@ -71,29 +66,6 @@ class Vitals(object):
             self.heart_rate = heart_rate
         if spo2 is not None:
             self.spo2 = spo2
-
-    @property
-    def conscious(self):
-        """Gets the conscious of this Vitals.  # noqa: E501
-
-        whether or not the character appears to be conscious  # noqa: E501
-
-        :return: The conscious of this Vitals.  # noqa: E501
-        :rtype: bool
-        """
-        return self._conscious
-
-    @conscious.setter
-    def conscious(self, conscious):
-        """Sets the conscious of this Vitals.
-
-        whether or not the character appears to be conscious  # noqa: E501
-
-        :param conscious: The conscious of this Vitals.  # noqa: E501
-        :type: bool
-        """
-
-        self._conscious = conscious
 
     @property
     def avpu(self):


### PR DESCRIPTION
* Remove 'conscious' vital;
* Update swagger yaml based on recent server changes.

Use with the client [ITM-409](https://github.com/NextCenturyCorporation/itm-evaluation-server/tree/ITM-409) branch and corresponding [PR](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/66).