### PR TITLE
ITM-420:  Added fentanyl lollipop

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1413,6 +1413,7 @@ components:
         - Epi Pen
         - Vented Chest Seal
         - Pain Medications
+        - Fentanyl Lollipop
         - Splint
         - Blood
         - IV Bag

--- a/swagger_client/models/supply_type_enum.py
+++ b/swagger_client/models/supply_type_enum.py
@@ -34,6 +34,7 @@ class SupplyTypeEnum(object):
     EPI_PEN = "Epi Pen"
     VENTED_CHEST_SEAL = "Vented Chest Seal"
     PAIN_MEDICATIONS = "Pain Medications"
+    FENTANYL_LOLLIPOP = "Fentanyl Lollipop"
     SPLINT = "Splint"
     BLOOD = "Blood"
     IV_BAG = "IV Bag"


### PR DESCRIPTION
Use the [ITM-420 server branch](https://github.com/NextCenturyCorporation/itm-evaluation-server/tree/ITM-420) and run soartech and adept session types.  You can also use the human ADM simulator to make sure you can choose the fentanyl lollipop treatment (location is ignored).

[Here's](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/68) the corresponding server PR.