### PR TITLE
ITM-385: Add test session and YAML examples

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -126,7 +126,7 @@ except ApiException as e:
 # create an instance of the API class
 api_instance = swagger_client.ItmTa2EvalApi(swagger_client.ApiClient(configuration))
 adm_name = 'adm_name_example' # str | A self-assigned ADM name.
-session_type = 'session_type_example' # str | the type of session to start (`eval` or a TA1 name)
+session_type = 'session_type_example' # str | the type of session to start (`eval`, `test`, or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
 kdma_training = false # bool | whether or not this is a training session with TA2 (optional) (default to false)
 max_scenarios = 56 # int | the maximum number of scenarios requested, not supported in `eval` sessions (optional)

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ options:
   -h, --help              Show this help message and exit
   --name adm_name         Specify the ADM name
   --profile adm_profile   Specify the ADM profile in terms of its alignment strategy
-  --session session_type  Specify session type. Session type must be `eval`, `adept`, or `soartech`.
+  --session session_type  Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
   --count scenario_count  Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
                           supported in `eval` sessions.
   --training              Put the server in training mode in which it returns the KDMA association for each action choice. Not supported
-                          in `eval` sessions.
+                          in `eval` or `test` sessions.
   --scenario scenario_id  Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
 ```
 
@@ -77,11 +77,11 @@ Runs Human input simulator.
 
 options:
   -h, --help              Show this help message and exit
-  --session session_type  Specify session type. Session type must be `eval`, `adept`, or `soartech`.
+  --session session_type  Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
   --count scenario_count  Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
                           supported in `eval` sessions.
   --training              Put the server in training mode in which it returns the KDMA association for each action choice. Not supported
-                          in `eval` sessions.
+                          in `eval` or `test` sessions.
   --scenario scenario_id  Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
 ```
 

--- a/docs/ItmTa2EvalApi.md
+++ b/docs/ItmTa2EvalApi.md
@@ -331,7 +331,7 @@ from pprint import pprint
 # create an instance of the API class
 api_instance = swagger_client.ItmTa2EvalApi()
 adm_name = 'adm_name_example' # str | A self-assigned ADM name.
-session_type = 'session_type_example' # str | the type of session to start (`eval` or a TA1 name)
+session_type = 'session_type_example' # str | the type of session to start (`eval`, `test`, or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
 kdma_training = false # bool | whether or not this is a training session with TA2 (optional) (default to false)
 max_scenarios = 56 # int | the maximum number of scenarios requested, not supported in `eval` sessions (optional)
@@ -349,7 +349,7 @@ except ApiException as e:
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **adm_name** | **str**| A self-assigned ADM name. | 
- **session_type** | **str**| the type of session to start (&#x60;eval&#x60; or a TA1 name) | 
+ **session_type** | **str**| the type of session to start (&#x60;eval&#x60;, &#x60;test&#x60;, or a TA1 name) | 
  **adm_profile** | **str**| a profile of the ADM in terms of its alignment strategy | [optional] 
  **kdma_training** | **bool**| whether or not this is a training session with TA2 | [optional] [default to false]
  **max_scenarios** | **int**| the maximum number of scenarios requested, not supported in &#x60;eval&#x60; sessions | [optional] 

--- a/itm/itm_adm_scenario_runner.py
+++ b/itm/itm_adm_scenario_runner.py
@@ -136,7 +136,6 @@ class ADMScenarioRunner(ScenarioRunner):
 
     def retrieve_scenario(self):
         self.adm_knowledge = ADMKnowledge() 
-        scenario: Scenario
         if self.custom_scenario_id:
             scenario = self.itm.start_scenario(session_id=self.session_id, scenario_id=self.custom_scenario_id)
         else:
@@ -145,7 +144,7 @@ class ADMScenarioRunner(ScenarioRunner):
             return True
         self.set_scenario(scenario)
         self.adm_knowledge.alignment_target = \
-            self.itm.get_alignment_target(self.session_id, self.adm_knowledge.scenario.id)
+            self.itm.get_alignment_target(self.session_id, self.adm_knowledge.scenario.id) if self.session_type != 'test' else None
         return False
 
     def set_scenario(self, scenario):
@@ -189,14 +188,14 @@ class ADMScenarioRunner(ScenarioRunner):
                     random_action.parameters = {"evac_id": self.get_random_evac_id(state)}
         return random_action
 
-    def get_random_supply(sellf, state: State):
+    def get_random_supply(self, state: State):
         supplies = [new_supply.type for new_supply in state.supplies if new_supply.quantity > 0]
         return random.choice(supplies)
 
     def get_random_character_id(self):
         return random.choice(self.adm_knowledge.all_character_ids)
 
-    def get_random_evac_id(state: State):
+    def get_random_evac_id(self, state: State):
         evac_id = 'unknown'
         if state.environment.decision_environment and state.environment.decision_environment.aid_delay:
             aid_delays = state.environment.decision_environment.aid_delay

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -179,8 +179,10 @@ class ITMHumanScenarioRunner(ScenarioRunner):
         if self.session_id is None:
             return "No active session; please start a session first."
         if self.scenario_id == None:
-            response: Scenario = \
-                self.itm.start_scenario(session_id=self.session_id, scenario_id=self.custom_scenario_id if self.custom_scenario_id else None)
+            if self.custom_scenario_id:
+                response = self.itm.start_scenario(session_id=self.session_id, scenario_id=self.custom_scenario_id)
+            else:
+                response = self.itm.start_scenario(session_id=self.session_id)
             self.current_probe_answered = False
             self.current_probe_id = ''
             if not response.session_complete:
@@ -207,8 +209,8 @@ class ITMHumanScenarioRunner(ScenarioRunner):
         return response
 
     def get_alignment_target_operation(self):
-        if self.kdma_training:
-            return "Getting alignment target is not supported in training mode."
+        if self.kdma_training or self.session_type == 'test':
+            return "Getting alignment target is not supported in test sessions or training mode."
         if self.session_id is None:
             return "No active session; please start a session first."
         if self.scenario_id is None:

--- a/itm_adm_mock.py
+++ b/itm_adm_mock.py
@@ -6,7 +6,7 @@ def main():
     parser.add_argument('--profile', metavar='adm_profile', required=False, 
                         help='Specify the ADM profile in terms of its alignment strategy')
     parser.add_argument('--session', required=True, metavar='session_type', help=\
-                        'Specify session type. Session type must be `eval`, `adept`, or `soartech`. ')
+                        'Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`. ')
     parser.add_argument('--count', type=int, metavar='scenario_count', help=\
                         'Run the specified number of scenarios. Otherwise, will run scenarios in '
                         'accordance with server defaults. Not supported in `eval` sessions.')
@@ -18,8 +18,8 @@ def main():
     scenario_id = args.scenario
     scenario_count = args.count
     if args.session:
-        if args.session not in ['soartech', 'adept', 'eval']:
-            parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
+        if args.session not in ['soartech', 'adept', 'eval', 'test']:
+            parser.error("Invalid session type. It must be one of 'soartech', 'adept', 'test', or 'eval'.")
         else:
             session_type = args.session
 

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -5,13 +5,13 @@ def main():
 
     parser = argparse.ArgumentParser(description='Runs Human input simulator.')
     parser.add_argument('--session', required=True, metavar='session_type', help=\
-                        'Specify session type. Session type must be `eval`, `adept`, or `soartech`. ')
+                        'Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.')
     parser.add_argument('--count', type=int, metavar='scenario_count', help=\
                         'Run the specified number of scenarios. Otherwise, will run scenarios in '
                         'accordance with server defaults. Not supported in `eval` sessions.')
     parser.add_argument('--training', action='store_true', default=False,
                         help='Put the server in training mode in which it returns the KDMA '
-                        'association for each action choice. Not supported in `eval` sessions.')
+                        'association for each action choice. Not supported in `eval` or `test` sessions.')
     parser.add_argument('--scenario', type=str, metavar='scenario_id',
                         help='Specify a scenario_id to run. Incompatible with count parameter '
                         'and `eval` sessions.')
@@ -20,8 +20,8 @@ def main():
     scenario_id = args.scenario
     scenario_count = args.count
     if args.session:
-        if args.session not in ['soartech', 'adept', 'eval']:
-            parser.error("Invalid session type. It must be one of 'soartech', 'adept', or 'eval'.")
+        if args.session not in ['soartech', 'adept', 'eval', 'test']:
+            parser.error("Invalid session type. It must be one of 'soartech', 'adept', 'test', or 'eval'.")
         else:
             session_type = args.session
 
@@ -32,6 +32,8 @@ def main():
             parser.error("Training mode is not supported in eval sessions.")
         if scenario_count is not None:
             parser.error("Scenario count is not supported in eval sessions.")
+    elif session_type == 'test' and args.training:
+        parser.error("Training mode is not supported in test sessions.")
 
     if scenario_count is not None:
         if scenario_count < 1:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -40,7 +40,7 @@ paths:
             type: string
         - name: session_type
           in: query
-          description: "the type of session to start (`eval` or a TA1 name)"
+          description: "the type of session to start (`eval`, `test`, or a TA1 name)"
           required: true
           style: form
           explode: true

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -657,7 +657,7 @@ class ItmTa2EvalApi(object):
 
         :param async_req bool
         :param str adm_name: A self-assigned ADM name. (required)
-        :param str session_type: the type of session to start (`eval` or a TA1 name) (required)
+        :param str session_type: the type of session to start (`eval`, `test`, or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
         :param bool kdma_training: whether or not this is a training session with TA2
         :param int max_scenarios: the maximum number of scenarios requested, not supported in `eval` sessions
@@ -683,7 +683,7 @@ class ItmTa2EvalApi(object):
 
         :param async_req bool
         :param str adm_name: A self-assigned ADM name. (required)
-        :param str session_type: the type of session to start (`eval` or a TA1 name) (required)
+        :param str session_type: the type of session to start (`eval`, `test`, or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
         :param bool kdma_training: whether or not this is a training session with TA2
         :param int max_scenarios: the maximum number of scenarios requested, not supported in `eval` sessions

--- a/swagger_client/config/test_action_path.json
+++ b/swagger_client/config/test_action_path.json
@@ -1,0 +1,11 @@
+{
+    "enabled": false,
+    "paths":[
+        {
+            "path":["mike-vitals","intend-evac-captain","cleanup"]
+        },
+        {
+            "path":["treat-civ","intend-evac-marine","check_blood_oxygen"]
+        }
+    ]
+}


### PR DESCRIPTION
- Rebuilt models;
- Added support for `test` session to all ADM client simulators (incompatible with training mode); and
- Fixed a few minor bugs in ADM client simulators.

See corresponding [server PR](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/70) and [branch](https://github.com/NextCenturyCorporation/itm-evaluation-server/tree/ITM-385).