### PR TITLE
ITM-478/521/522:  Integrate with TA1 Dry Run servers

### DIFF
--- a/docs/AlignmentResults.md
+++ b/docs/AlignmentResults.md
@@ -6,7 +6,6 @@ Name | Type | Description | Notes
 **alignment_source** | [**list[AlignmentSource]**](AlignmentSource.md) |  | 
 **alignment_target_id** | **str** | ID of desired profile to align responses to. | 
 **score** | **float** | Measured alignment, 0 (completely unaligned) - 1 (completely aligned). | 
-**kdma_values** | [**list[KDMAValue]**](KDMAValue.md) | Computed KDMA profile from results | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -2,7 +2,7 @@ from enum import Enum
 from swagger_client.models import Scenario, State, Action
 from swagger_client.models.action_type_enum import ActionTypeEnum
 from swagger_client.models.injury_location import InjuryLocation
-from .itm_scenario_runner import ScenarioRunner, get_swagger_class_enum_values, SOARTECH_ALIGNMENT, ADEPT_ALIGNMENT
+from .itm_scenario_runner import ScenarioRunner, get_swagger_class_enum_values, SOARTECH_QOL_ALIGNMENT, SOARTECH_VOL_ALIGNMENT, ADEPT_MJ_ALIGNMENT, ADEPT_IO_ALIGNMENT
 import traceback
 
 
@@ -225,7 +225,10 @@ class ITMHumanScenarioRunner(ScenarioRunner):
         if self.kdma_training == False:
             return "Session alignment can only be requested during a training session."
         try:
-            target_id = SOARTECH_ALIGNMENT if self.session_type == 'soartech' else ADEPT_ALIGNMENT
+            if self.session_type == 'soartech':
+                target_id = SOARTECH_QOL_ALIGNMENT if 'qol' in self.scenario_id else SOARTECH_VOL_ALIGNMENT
+            else:
+                target_id = ADEPT_MJ_ALIGNMENT if 'MJ' in self.scenario_id else ADEPT_IO_ALIGNMENT
             return self.itm.get_session_alignment(self.session_id, target_id)
         except:
             # An exception will occur if no probes have been answered yet.

--- a/itm/itm_scenario_runner.py
+++ b/itm/itm_scenario_runner.py
@@ -9,10 +9,14 @@ import random
 def get_swagger_class_enum_values(klass):
     return [getattr(klass,i) for i in dir(klass) if not i.startswith("_") and isinstance(getattr(klass,i), str)]
 
-soartech_alignment_targets = ['qol_1', 'qol_5', 'qol_9', 'vol_1', 'vol_5', 'vol_9']
-SOARTECH_ALIGNMENT = random.choice(soartech_alignment_targets)
-adept_alignment_targets = ['moral-judgement-1', 'moral-judgement-5', 'moral-judgement-9', 'ingroup-bias-1', 'ingroup-bias-5', 'ingroup-bias-9']
-ADEPT_ALIGNMENT = random.choice(adept_alignment_targets)
+soartech_qol_alignment_targets = ['qol_1', 'qol_5', 'qol_9']
+soartech_vol_alignment_targets = ['vol_1', 'vol_5', 'vol_9']
+SOARTECH_QOL_ALIGNMENT = random.choice(soartech_qol_alignment_targets)
+SOARTECH_VOL_ALIGNMENT = random.choice(soartech_vol_alignment_targets)
+adept_mj_alignment_targets = ['ADEPT-DryRun-Moral judgement-0.1', 'ADEPT-DryRun-Moral judgement-0.5', 'ADEPT-DryRun-Moral judgement-0.9']
+adept_io_alignment_targets = ['ADEPT-DryRun-Ingroup Bias-0.1', 'ADEPT-DryRun-Ingroup Bias-0.5', 'ADEPT-DryRun-Ingroup Bias-0.9']
+ADEPT_MJ_ALIGNMENT = random.choice(adept_mj_alignment_targets)
+ADEPT_IO_ALIGNMENT = random.choice(adept_io_alignment_targets)
 
 class ScenarioRunner(ABC):
     def __init__(self):

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -42,7 +42,7 @@ The implementation of this function should be replaced with decision-making logi
 """
 
 import argparse
-from itm.itm_scenario_runner import get_swagger_class_enum_values, SOARTECH_ALIGNMENT, ADEPT_ALIGNMENT
+from itm.itm_scenario_runner import get_swagger_class_enum_values, SOARTECH_QOL_ALIGNMENT, SOARTECH_VOL_ALIGNMENT, ADEPT_MJ_ALIGNMENT, ADEPT_IO_ALIGNMENT
 import swagger_client
 import random
 from typing import List
@@ -217,7 +217,10 @@ def main():
                 if args.training:
                     try:
                         # A TA2 performer would probably want to get alignment target ids from configuration or command-line.
-                        target_id = SOARTECH_ALIGNMENT if session_type == 'soartech' else ADEPT_ALIGNMENT
+                        if session_type == 'soartech':
+                            target_id = SOARTECH_QOL_ALIGNMENT if 'qol' in scenario.id else SOARTECH_VOL_ALIGNMENT
+                        else:
+                            target_id = ADEPT_MJ_ALIGNMENT if 'MJ' in scenario.id else ADEPT_IO_ALIGNMENT
                         print(itm.get_session_alignment(session_id=session_id, target_id=target_id))
                     except Exception as e:
                         # An exception will occur if no probes have been answered yet, so just log this succinctly.

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -434,7 +434,6 @@ components:
         - alignment_source
         - alignment_target_id
         - score
-        - kdma_values
       type: object
       description: Computed KDMA profile and alignment score for a set of decisions.
       properties:
@@ -453,12 +452,6 @@ components:
           description: Measured alignment, 0 (completely unaligned) - 1 (completely aligned).
           minimum: 0
           maximum: 1
-        kdma_values:
-          title: Kdma Values
-          type: array
-          items:
-            "$ref": "#/components/schemas/KDMA_Value"
-          description: Computed KDMA profile from results
     AlignmentSource:
       title: AlignmentSource
       required:

--- a/swagger_client/models/alignment_results.py
+++ b/swagger_client/models/alignment_results.py
@@ -30,28 +30,24 @@ class AlignmentResults(object):
     swagger_types = {
         'alignment_source': 'list[AlignmentSource]',
         'alignment_target_id': 'str',
-        'score': 'float',
-        'kdma_values': 'list[KDMAValue]'
+        'score': 'float'
     }
 
     attribute_map = {
         'alignment_source': 'alignment_source',
         'alignment_target_id': 'alignment_target_id',
-        'score': 'score',
-        'kdma_values': 'kdma_values'
+        'score': 'score'
     }
 
-    def __init__(self, alignment_source=None, alignment_target_id=None, score=None, kdma_values=None):  # noqa: E501
+    def __init__(self, alignment_source=None, alignment_target_id=None, score=None):  # noqa: E501
         """AlignmentResults - a model defined in Swagger"""  # noqa: E501
         self._alignment_source = None
         self._alignment_target_id = None
         self._score = None
-        self._kdma_values = None
         self.discriminator = None
         self.alignment_source = alignment_source
         self.alignment_target_id = alignment_target_id
         self.score = score
-        self.kdma_values = kdma_values
 
     @property
     def alignment_source(self):
@@ -125,31 +121,6 @@ class AlignmentResults(object):
             raise ValueError("Invalid value for `score`, must not be `None`")  # noqa: E501
 
         self._score = score
-
-    @property
-    def kdma_values(self):
-        """Gets the kdma_values of this AlignmentResults.  # noqa: E501
-
-        Computed KDMA profile from results  # noqa: E501
-
-        :return: The kdma_values of this AlignmentResults.  # noqa: E501
-        :rtype: list[KDMAValue]
-        """
-        return self._kdma_values
-
-    @kdma_values.setter
-    def kdma_values(self, kdma_values):
-        """Sets the kdma_values of this AlignmentResults.
-
-        Computed KDMA profile from results  # noqa: E501
-
-        :param kdma_values: The kdma_values of this AlignmentResults.  # noqa: E501
-        :type: list[KDMAValue]
-        """
-        if kdma_values is None:
-            raise ValueError("Invalid value for `kdma_values`, must not be `None`")  # noqa: E501
-
-        self._kdma_values = kdma_values
 
     def to_dict(self):
         """Returns the model properties as a dict"""


### PR DESCRIPTION
- Removed `kdma_values` from `AlignmentResults`, in accordance with program changes. (ITM-478)
- Use dryrun alignment targets (although SoarTech's are still TBD).

See [server PR](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/91)