### PR TITLE
ITM-672:  Add solo (standalone) training mode

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -128,7 +128,7 @@ api_instance = swagger_client.ItmTa2EvalApi(swagger_client.ApiClient(configurati
 adm_name = 'adm_name_example' # str | A self-assigned ADM name.
 session_type = 'session_type_example' # str | the type of session to start (`eval`, `test`, or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
-kdma_training = false # bool | whether or not this is a training session with TA2 (optional) (default to false)
+kdma_training = 'kdma_training_example' # str | whether this is a `full`, `solo`, or non-training session with TA2 (optional)
 max_scenarios = 56 # int | the maximum number of scenarios requested, not supported in `eval` sessions (optional)
 
 try:

--- a/README.md
+++ b/README.md
@@ -47,21 +47,21 @@ pip3 install -r requirements.txt
  Run `itm_minimal_runner.py` in the root directory:
 
 ```
-usage: itm_minimal_runner.py [-h] --name adm_name [--profile adm_profile] --session session_type [--count scenario_count]
-                             [--training] [--scenario scenario_id]
+usage: itm_minimal_runner.py [-h] --name adm_name --session session_type [--profile adm_profile] [--count scenario_count]
+                             [--training training_mode] [--scenario scenario_id]
 
 Runs ADM simulator.
 
 options:
-  -h, --help              Show this help message and exit
-  --name adm_name         Specify the ADM name
-  --profile adm_profile   Specify the ADM profile in terms of its alignment strategy
-  --session session_type  Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
-  --count scenario_count  Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
-                          supported in `eval` sessions.
-  --training              Put the server in training mode in which it returns the KDMA association for each action choice. Not supported
-                          in `eval` or `test` sessions.
-  --scenario scenario_id  Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
+  -h, --help               Show this help message and exit
+  --name adm_name          Specify the ADM name
+  --session session_type   Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
+  --profile adm_profile    Specify the ADM profile in terms of its alignment strategy
+  --count scenario_count   Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
+                           supported in `eval` sessions.
+  --training training_mode Put the server in either `full` or `solo` training mode in which it returns the KDMA association for each
+                           action choice. `full` training mode also allows calls for session alignment. Not supported in `eval` or `test` sessions.
+  --scenario scenario_id   Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
 ```
 
 ### Running the Human input simulator
@@ -71,18 +71,18 @@ The Human input simulator is used for testing specific action/parameter sequence
 Inside the root directory, run `itm_human_input.py`:
 
 ```
-usage: itm_human_input.py [-h] --session session_type [--count scenario_count] [--training] [--scenario scenario_id]
+usage: itm_human_input.py [-h] --session session_type [--count scenario_count] [--training training_mode] [--scenario scenario_id]
 
 Runs Human input simulator.
 
 options:
-  -h, --help              Show this help message and exit
-  --session session_type  Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
-  --count scenario_count  Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
-                          supported in `eval` sessions.
-  --training              Put the server in training mode in which it returns the KDMA association for each action choice. Not supported
-                          in `eval` or `test` sessions.
-  --scenario scenario_id  Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
+  -h, --help               Show this help message and exit
+  --session session_type   Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
+  --count scenario_count   Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
+                           supported in `eval` sessions.
+  --training training_mode Put the server in either `full` or `solo` training mode in which it returns the KDMA association for each
+                           action choice. `full` training mode also allows calls for session alignment. Not supported in `eval` or `test` sessions.
+  --scenario scenario_id   Specify a scenario_id to run. Incompatible with count parameter and `eval` sessions.
 ```
 
 ### Available Actions

--- a/docs/ItmTa2EvalApi.md
+++ b/docs/ItmTa2EvalApi.md
@@ -333,7 +333,7 @@ api_instance = swagger_client.ItmTa2EvalApi()
 adm_name = 'adm_name_example' # str | A self-assigned ADM name.
 session_type = 'session_type_example' # str | the type of session to start (`eval`, `test`, or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
-kdma_training = false # bool | whether or not this is a training session with TA2 (optional) (default to false)
+kdma_training = 'kdma_training_example' # str | whether this is a `full`, `solo`, or non-training session with TA2 (optional)
 max_scenarios = 56 # int | the maximum number of scenarios requested, not supported in `eval` sessions (optional)
 
 try:
@@ -351,7 +351,7 @@ Name | Type | Description  | Notes
  **adm_name** | **str**| A self-assigned ADM name. | 
  **session_type** | **str**| the type of session to start (&#x60;eval&#x60;, &#x60;test&#x60;, or a TA1 name) | 
  **adm_profile** | **str**| a profile of the ADM in terms of its alignment strategy | [optional] 
- **kdma_training** | **bool**| whether or not this is a training session with TA2 | [optional] [default to false]
+ **kdma_training** | **str**| whether this is a &#x60;full&#x60;, &#x60;solo&#x60;, or non-training session with TA2 | [optional] 
  **max_scenarios** | **int**| the maximum number of scenarios requested, not supported in &#x60;eval&#x60; sessions | [optional] 
 
 ### Return type

--- a/docs/Vitals.md
+++ b/docs/Vitals.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **mental_status** | [**MentalStatusEnum**](MentalStatusEnum.md) |  | [optional] 
 **breathing** | [**BreathingLevelEnum**](BreathingLevelEnum.md) |  | [optional] 
 **heart_rate** | [**HeartRateEnum**](HeartRateEnum.md) |  | [optional] 
-**triss** | **float** | Trauma Score and Injury Severity Score | [optional] 
+**triss** | **float** | Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict a patient&#x27;s probability of survival  | [optional] 
 **spo2** | [**BloodOxygenEnum**](BloodOxygenEnum.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -27,7 +27,7 @@ class TagTypes(Enum):
 ACTIONS_WITHOUT_CHARACTERS = ["DIRECT_MOBILE_CHARACTERS", "END_SCENE", "MESSAGE", "SEARCH", "SITREP"]
 
 class ITMHumanScenarioRunner(ScenarioRunner):
-    def __init__(self, session_type, kdma_training=False, max_scenarios=-1, scenario_id=None):
+    def __init__(self, session_type, kdma_training=None, max_scenarios=-1, scenario_id=None):
         super().__init__()
         self.username = session_type + " ITM Human"
         self.session_type = session_type
@@ -225,8 +225,8 @@ class ITMHumanScenarioRunner(ScenarioRunner):
             return "No active session; please start a session first."
         if self.scenario_id is None:
             return "No active scenario; please start a scenario first."
-        if self.kdma_training == False:
-            return "Session alignment can only be requested during a training session."
+        if self.kdma_training != 'full':
+            return "Session alignment can only be requested during a full training session."
         try:
             if self.session_type == 'soartech':
                 target_id = SOARTECH_QOL_ALIGNMENT if 'qol' in self.scenario_id else SOARTECH_VOL_ALIGNMENT

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -9,9 +9,9 @@ def main():
     parser.add_argument('--count', type=int, metavar='scenario_count', help=\
                         'Run the specified number of scenarios. Otherwise, will run scenarios in '
                         'accordance with server defaults. Not supported in `eval` sessions.')
-    parser.add_argument('--training', action='store_true', default=False,
-                        help='Put the server in training mode in which it returns the KDMA '
-                        'association for each action choice. Not supported in `eval` or `test` sessions.')
+    parser.add_argument('--training', metavar='training_mode', default=None,
+                        help='Put the server in either `full` or `solo` training mode in which it returns the KDMA association for each '
+                        'action choice. `full` training mode also allows calls for session alignment. Not supported in `eval` or `test` sessions.')
     parser.add_argument('--scenario', type=str, metavar='scenario_id',
                         help='Specify a scenario_id to run. Incompatible with count parameter '
                         'and `eval` sessions.')
@@ -19,11 +19,13 @@ def main():
     args = parser.parse_args()
     scenario_id = args.scenario
     scenario_count = args.count
-    if args.session:
-        if args.session not in ['soartech', 'adept', 'eval', 'test']:
-            parser.error("Invalid session type. It must be one of 'soartech', 'adept', 'test', or 'eval'.")
-        else:
-            session_type = args.session
+    if args.session not in ['soartech', 'adept', 'eval', 'test']:
+        parser.error("Invalid session type. It must be one of 'soartech', 'adept', 'test', or 'eval'.")
+    else:
+        session_type = args.session
+
+    if args.training and args.training not in ['full', 'solo']:
+        parser.error("Invalid training mode. It must be 'full' or 'solo' (or omitted entirely).")
 
     if session_type == 'eval':
         if scenario_id:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -49,13 +49,12 @@ paths:
             example: eval
         - name: kdma_training
           in: query
-          description: whether or not this is a training session with TA2
+          description: "whether this is a `full`, `solo`, or non-training session with TA2"
           required: false
           style: form
           explode: true
           schema:
-            type: boolean
-            default: false
+            type: string
         - name: max_scenarios
           in: query
           description:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -975,7 +975,9 @@ components:
         triss:
           type: number
           format: float
-          description: Trauma Score and Injury Severity Score
+          description: >
+            Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict
+            a patient's probability of survival
           minimum: 0.0
           maximum: 100.0
         spo2:

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -659,7 +659,7 @@ class ItmTa2EvalApi(object):
         :param str adm_name: A self-assigned ADM name. (required)
         :param str session_type: the type of session to start (`eval`, `test`, or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
-        :param bool kdma_training: whether or not this is a training session with TA2
+        :param str kdma_training: whether this is a `full`, `solo`, or non-training session with TA2
         :param int max_scenarios: the maximum number of scenarios requested, not supported in `eval` sessions
         :return: str
                  If the method is called asynchronously,
@@ -685,7 +685,7 @@ class ItmTa2EvalApi(object):
         :param str adm_name: A self-assigned ADM name. (required)
         :param str session_type: the type of session to start (`eval`, `test`, or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
-        :param bool kdma_training: whether or not this is a training session with TA2
+        :param str kdma_training: whether this is a `full`, `solo`, or non-training session with TA2
         :param int max_scenarios: the maximum number of scenarios requested, not supported in `eval` sessions
         :return: str
                  If the method is called asynchronously,

--- a/swagger_client/models/vitals.py
+++ b/swagger_client/models/vitals.py
@@ -183,7 +183,7 @@ class Vitals(object):
     def triss(self):
         """Gets the triss of this Vitals.  # noqa: E501
 
-        Trauma Score and Injury Severity Score  # noqa: E501
+        Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict a patient's probability of survival   # noqa: E501
 
         :return: The triss of this Vitals.  # noqa: E501
         :rtype: float
@@ -194,7 +194,7 @@ class Vitals(object):
     def triss(self, triss):
         """Sets the triss of this Vitals.
 
-        Trauma Score and Injury Severity Score  # noqa: E501
+        Trauma and Injury Severity Score, a calculation that combines patient vitals and injury severity to predict a patient's probability of survival   # noqa: E501
 
         :param triss: The triss of this Vitals.  # noqa: E501
         :type: float


### PR DESCRIPTION
Added solo (standalone) training mode that returns kdmas but doesn't request session alignment.
Test with server [ITM-672 branch](https://github.com/NextCenturyCorporation/itm-evaluation-server/tree/ITM-672).
This is another one that's kind of a pain to test fully...

This PR turns the `--kdma_training` boolean flag into an optional string command line parameter that can be `full` or `solo`.  So `--kdma_training full` is just like the `--kdma_training` on the old CLI.  The only difference is that `solo` training sessions don't support calling for session alignment, and can be run without a connection to a TA1 server.  And on the server side, it never calls for probe alignment.

To test, you should try some or all of the following:
- Test basic command line functionality:  -h for help and bad/illegal parameter combos.  See the README or `-h` output for the command line restrictions.
- Test the itm_minimal_runner with a soartech and adept non-training session (no `--training flag`)
  - Make sure the evaluation scenarios are running.
- Test the itm_minimal_runner with a soartech and adept solo training session (`--training solo`).
  - Make sure no calls to TA1 are made and no session alignment is returned after each scenario.
- Test the itm_minimal_runner with a soartech and adept full training session (`--training full`).
  - Make sure calls to TA1 are made and session alignment is returned after each scenario.
  - Note that this takes a long time for adept, so feel free to interrupt it once you see it's working.
- Test `itm_human_input.py` each of the above three ways, and at least go through an action or two to ensure that KDMA values are returned in available actions for all training sessions, but calls to TA1 are not made in solo session.
- Test the itm_minimal_runner with an evaluation session (`--eval`).
- Feel free to hack up a client script to request session alignment in solo training sessions, to see that it's properly handled.

When testing runs other than full training sessions, you can comment out lines 107-108 of `itm_session.py`.  This will save you from having to wait for it to try to connect to TA1 for alignment targets.