### PR TITLE
ITM-842: Break up README into generic and domain-specific components; add domain to CLI

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -128,12 +128,13 @@ api_instance = swagger_client.ItmTa2EvalApi(swagger_client.ApiClient(configurati
 adm_name = 'adm_name_example' # str | A self-assigned ADM name.
 session_type = 'session_type_example' # str | the type of session to start (`eval`, `test`, or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
+domain = 'domain_example' # str | A domain supported by the ITM evaluation server (optional)
 kdma_training = 'kdma_training_example' # str | whether this is a `full`, `solo`, or non-training session with TA2 (optional)
 max_scenarios = 56 # int | the maximum number of scenarios requested, not supported in `eval` sessions (optional)
 
 try:
     # Start a new session
-    api_response = api_instance.start_session(adm_name, session_type, adm_profile=adm_profile, kdma_training=kdma_training, max_scenarios=max_scenarios)
+    api_response = api_instance.start_session(adm_name, session_type, adm_profile=adm_profile, domain=domain, kdma_training=kdma_training, max_scenarios=max_scenarios)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling ItmTa2EvalApi->start_session: %s\n" % e)

--- a/README-triage.md
+++ b/README-triage.md
@@ -1,0 +1,75 @@
+# In the Moment (ITM) - Triage domain
+
+This README provides details for the `triage` domain within ITM. See `README.md` in the root directory for installation instructions and descriptions/FAQs for non-domain-specific actions and topics.  Note that this domain was designed to be used in a VR simulator written in Unity.
+
+### Available Actions
+Further details can be found in the Triage domain FAQ below.
+
+* `APPLY_TREATMENT`
+  * Attempts to apply the specified `treatment` to the specified `location` on the specified `character_id`.  Also reveals discoverable injuries and certain basic vitals from the character.
+    * requires `character_id`
+    * requires parameter `treatment` with a value taken from the `SupplyTypeEnum` object.
+    * requires parameter `location` with a value taken from the `InjuryLocationEnum` object.
+* `CHECK_ALL_VITALS`
+  * Reveals all `Vitals` and discoverable injuries for the specified `character_id`.
+    * requires `character_id`
+    * If no Pulse Oximeter is available in supplies, then blood oxygen (`spo2`) will not be returned.
+* `CHECK_BLOOD_OXYGEN`
+  * Reveals `spo2`, discoverable injuries, and certain basic vitals for the specified `character_id`.
+    * requires `character_id`
+    * requires a Pulse Oximeter in supplies
+* `CHECK_PULSE`
+  * Reveals `heart_rate`, discoverable injuries, and certain basic vitals for the specified `character_id`.
+    * requires `character_id`
+* `CHECK_RESPIRATION`
+  * Reveals discoverable injuries and certain basic vitals for the specified `character_id`.
+    * requires `character_id`
+* `DIRECT_MOBILE_CHARACTERS`
+  * Reveals the `ambulatory`, `mental_status`, and `avpu` vitals from mobile, responsive, alert characters.
+    * no further requirements
+* `MOVE_TO_EVAC`
+  * Chooses to transfer the specified `character_id` to the specified `aid_id`. It is assumed that others can perform the actual transfer so the medic can return to triage.
+    * requires `character_id`
+    * requires parameter `aid_id`
+* `SITREP`
+  * Request a situation report (basic health and status) from the specified `character_id`, or all characters in the scene. Reveals discoverable injuries and certain basic vitals for responsive characters.
+    * accepts **optional** `character_id`
+* `TAG_CHARACTER`
+  * Apply the specified triage tag to the specified `character`
+    * requires `character_id`
+    * requires parameter `category` with a value taken from the `CharacterTagEnum` object.
+
+### Triage Domain FAQ
+
+1. What are "certain basic vitals" from the action descriptions above?
+   * Basic vitals include `avpu`, `ambulatory`, `mental_status`, `triss`, and `breathing`. These are revealed by `SITREP`, `APPLY_TREATMENT`, and all `CHECK_*` actions.
+2. What is `SITREP`, and what exactly does it do?
+   * `SITREP` was developed as a military analogue to parts of the Sort and Assess phases of SALT triage implemented in the Unity Simulator.  It combines the *wavers check* (e.g., "Wave if you can hear my voice") in which responsive patients will wave, and an initial assessment of patient condition.  `SITREP` is meant to mimic these stages of SALT in a military setting in which people are probably on comms or radios, or calling out vocally to nearby allies.
+   * Specifically, `SITREP` reveals discoverable injuries (setting their `status` to `discovered`) and certain vitals from responsive patients: all vitals except `sp02` and `heart_rate`. It also sets the `visited` flags for these patients. Responsive patients are those with a `mental_status` of `CALM`, `UPSET`, OR `AGONY`.  ADMs can direct a `SITREP` at a single character, or all characters at once.  Elapsed time is proportional to the number of respondents.
+3. What is `DIRECT_MOBILE_CHARACTERS`, and what exactly does it do?
+   * `DIRECT_MOBILE_CHARACTERS` was added to have an analogue for the Unity Simulator's *walkers check* (e.g., "If you are able, please move to the safe zone.")
+   * Because ITM scenarios to date do not have defined safe zones, all it does is reveal the `ambulatory` vital from mobile, responsive characters: those with `ambulatory` of True and `mental_status` of `CALM`, `UPSET`, OR `AGONY`.
+4. How is `visited` determined?
+   * Most characters start with `visited` set to False, meaning the medic has not approached or otherwise assessed the patient. These characters will have vitals and discoverable injuries initially hidden to the ADM (i.e., not in the `state`). When certain actions are taken (those mentioned in question #1 above), basic vitals and discoverable injuries will be revealed (setting injury `status` to `discovered`), and `visited` will be set to True.
+5. Does `elapsed_time` have any event on patient health?
+   * No. And note that the elapsed time for each action has not been vetted by ITM medical SMEs and should not be used in decision-making.
+6. What exactly is `unstructured_postassess` in the `character` object?  It's always `None`.
+   * The `unstructured_postassess` property is for TA1 scenario designers to provide an updated unstructured text description of the character and/or his/her injuries. After the character is assessed/visited, the contents of the `unstructured_postassess` property are copied to the `unstructured` property.  It's always `None` because it is not exposed to ADMs, only copied to `unstructured`, which is exposed to ADMs.
+7. What happens if I treat an `Amputation` injury with a `Nasopharyngeal airway` treatment?
+   * As long as there are sufficient supplies, the TA3 Server will not reject an `APPLY_TREATMENT` attempt. However, not all treatments actually treat an injury (like in the example above). In these cases, the supply will be used, time will elapse, the character will be `visited`, and certain vitals will be revealed, but the injury's `status` will NOT change to `treated`. The mapping of correct treatments to injury types typically matches the behavior in the Unity simulator.
+8. What `location` should I use when applying a `Blanket` to a patient?
+   * When applying a `Blanket`, `location` is required but ignored-- the effect is the same: `Character.has_blanket` is set to True.  Note that this has no effect on patient vitals or injuries.
+9. My ADM correctly treated an Amputation injury with a Tourniquet, but nothing happened, except for time advancing. Why?
+   * This can happen for one of two reasons:
+      * Scenario designers have the ability to alter the state after any action, potentially overwriting or overriding ADM actions, giving the appearance of erasing history.  Typically, if a scenarios calls for actions to be "interrupted" or "intent only," they will configure action mappings to be `intent_only`, so ADMs know that they are expressing an intention instead of taking an action.
+      * If an ADM attempts to treat an injury that is already treated, then nothing will change other than a little bit of time passing.  If the character was previously unvisited, then basic vitals and other discoverable injuries will NOT be revealed as they normally would be after a treatment attempt.
+10. Sometimes the actions returned in `get_available_actions` are "fully qualified" (with all `parameters`), but other times they are not. How do we know if the action will trigger its effects?
+    * TA1 scenario designers specify action mappings that include the necessary action parameters to trigger a probe response. If an action mapping contains `APPLY_TREATMENT` with a `character_id` but no `parameters`, then TA2 will have to fill in parameters (e.g., `treatment` and `location`), but any treatment of the character will result in probe response.
+    * **NOTE** It's essential that the `action_id` of the TA2 action match the `action_id` of the original, corresponding action from `get_available_actions`.  Otherwise, the probe response might not be sent.
+11. What domain-specific actions can be performed on `unseen` characters?
+    * Only `MOVE_TO_EVAC`.
+12. Is there any domain-specific `relevant_state` that might be used in Events and what are the semantics for interpreting them in the scene?
+    * The `relevant_state` property is a list of string paths within the `State` object, in which indexed lists are context-sensitive.  Some of these are domain-specific:
+      * for `Aid` , it's the `id`
+      * for `Supplies`, it's the `type`
+      * for `Injury`, it's the `location`

--- a/README.md
+++ b/README.md
@@ -89,30 +89,8 @@ options:
 ```
 
 ### Available Actions
-Further details can be found in the ITM Server FAQ below.
+Further details about these actions can be found in the ITM Server FAQ below.  Domain-specific actions and FAQs are available in `README-<domainname>.md`.
 
-* `APPLY_TREATMENT`
-  * Attempts to apply the specified `treatment` to the specified `location` on the specified `character_id`.  Also reveals discoverable injuries and certain basic vitals from the character.
-    * requires `character_id`
-    * requires parameter `treatment` with a value taken from the `SupplyTypeEnum` object.
-    * requires parameter `location` with a value taken from the `InjuryLocationEnum` object.
-* `CHECK_ALL_VITALS`
-  * Reveals all `Vitals` and discoverable injuries for the specified `character_id`.
-    * requires `character_id`
-    * If no Pulse Oximeter is available in supplies, then blood oxygen (`spo2`) will not be returned.
-* `CHECK_BLOOD_OXYGEN`
-  * Reveals `spo2`, discoverable injuries, and certain basic vitals for the specified `character_id`.
-    * requires `character_id`
-    * requires a Pulse Oximeter in supplies
-* `CHECK_PULSE`
-  * Reveals `heart_rate`, discoverable injuries, and certain basic vitals for the specified `character_id`.
-    * requires `character_id`
-* `CHECK_RESPIRATION`
-  * Reveals discoverable injuries and certain basic vitals for the specified `character_id`.
-    * requires `character_id`
-* `DIRECT_MOBILE_CHARACTERS`
-  * Reveals the `ambulatory`, `mental_status`, and `avpu` vitals from mobile, responsive, alert characters.
-    * no further requirements
 * `END_SCENE`
   * Equivalent to the ADM choosing "none of the above" available actions.
     * no further requirements
@@ -122,70 +100,37 @@ Further details can be found in the ITM Server FAQ below.
 * `MOVE_TO`
   * Moves the ADM to the location of the specified `character_id`, making characters in the present scene "unseen".
     * requires `character_id` whose `unseen` property is set to True
-* `MOVE_TO_EVAC`
-  * Chooses to transfer the specified `character_id` to the specified `aid_id`. It is assumed that others can perform the actual transfer so the medic can return to triage.
-    * requires `character_id`
-    * requires parameter `aid_id`
 * `SEARCH`
   * Attempts to search for additional characters, moving the ADM to the a new location that might have found characters.
     * no further requirements
-* `SITREP`
-  * Request a situation report (basic health and status) from the specified `character_id`, or all characters in the scene. Reveals discoverable injuries and certain basic vitals for responsive characters.
-    * accepts **optional** `character_id`
-* `TAG_CHARACTER`
-  * Apply the specified triage tag to the specified `character`
-    * requires `character_id`
-    * requires parameter `category` with a value taken from the `CharacterTagEnum` object.
 
 ### ITM TA3 Server FAQ
 
-1. What are "certain basic vitals" from the action descriptions above?
-   * Basic vitals include `avpu`, `ambulatory`, `mental_status`, `triss`, and `breathing`. These are revealed by `SITREP`, `APPLY_TREATMENT`, and all `CHECK_*` actions.
-2. What is a "scene" and how do I know when a scene has changed?
+1. What is a "scene" and how do I know when a scene has changed?
    * It can be confusing because a scene can mean a few different things:
-     * A scene is a narrative construct, where within a scenario a human decision-maker moves between one physical area and another, each with a different set of characters.  The human in the sim literally moves (or is teleported) to a different scene, whereas the ADM gets an updated state with changes to structured and unstructured data, conveying the scene change.
-     * A scene is also a logical construct in TA1 scenario configuration.  If an ADM action changes anything other than character vitals or injuries, supplies, and elapsed time, then internally the logical scene changes-- even within a single narrative scene. In particular, when action mappings change (mapping from actions to probe responses), the logical scene must change even if the narrative/physical scene does not.
-     * The scene should be transparent to the ADM: it should not affect decision-making and the state always reflects the current scene. However, the best indication that a scene has changed is if the list of available actions changes beyond the removal of the most recently taken action.
-3. What is `SITREP`, and what exactly does it do?
-   * `SITREP` was developed as a military analogue to parts of the Sort and Assess phases of SALT triage implemented in the Unity Simulator.  It combines the *wavers check* (e.g., "Wave if you can hear my voice") in which responsive patients will wave, and an initial assessment of patient condition.  `SITREP` is meant to mimic these stages of SALT in a military setting in which people are probably on comms or radios, or calling out vocally to nearby allies.
-   * Specifically, `SITREP` reveals discoverable injuries (setting their `status` to `discovered`) and certain vitals from responsive patients: all vitals except `sp02` and `heart_rate`. It also sets the `visited` flags for these patients. Responsive patients are those with a `mental_status` of `CALM`, `UPSET`, OR `AGONY`.  ADMs can direct a `SITREP` at a single character, or all characters at once.  Elapsed time is proportional to the number of respondents.
-4. What is `DIRECT_MOBILE_CHARACTERS`, and what exactly does it do?
-   * `DIRECT_MOBILE_CHARACTERS` was added to have an analogue for the Unity Simulator's *walkers check* (e.g., "If you are able, please move to the safe zone.")
-   * Because ITM scenarios to date do not have defined safe zones, all it does is reveal the `ambulatory` vital from mobile, responsive characters: those with `ambulatory` of True and `mental_status` of `CALM`, `UPSET`, OR `AGONY`.
-5. What is `SEARCH`, and what exactly does it do?
-   * `SEARCH` models a medical decision-maker searching for additional patients prior to assessing or treating the patients already in the scene.  As a result, additional (found) characters may appear in the returned `state`.
-6. How is `visited` determined?
-   * Most characters start with `visited` set to False, meaning the medic has not approached or otherwise assessed the patient. These characters will have vitals and discoverable injuries initially hidden to the ADM (i.e., not in the `state`). When certain actions are taken (those mentioned in question #1 above), basic vitals and discoverable injuries will be revealed (setting injury `status` to `discovered`), and `visited` will be set to True.
-7. How does `elapsed_time` work?
+     * A scene is a narrative construct, where within a scenario a theoretical human decision-maker moves between one physical area and another, each with a different set of characters.  In domains that are realized in a VR simulator, the human in the sim literally moves (or is teleported) to a different scene, whereas the ADM gets an updated state with changes to structured and unstructured data, conveying the scene change.
+     * A scene is also a logical construct in TA1 scenario configuration.  If an ADM action changes anything other than elapsed time (or other domain-specific factors), then internally the logical scene changes-- even within a single narrative scene. In particular, when action mappings change (mapping from actions to probe responses), the logical scene must change even if the narrative/physical scene does not.
+     * The scene should be transparent to the ADM: it should not affect decision-making and the state always reflects the current scene. However, the scene ID is available in the `meta_info` property of the `State`.
+2. What is the `SEARCH` action, and what exactly does it do?
+   * `SEARCH` models a decision-maker searching for additional characters, leaving characters in the current scene.  As a result, new (found) characters may appear in the returned `state`, while characters from the previous scene will be "unseen" (`unseen: true`).
+3. What is the `MOVE_TO` action, and what exactly does it do?
+   * This action simulates a decision-maker moving from one "room" to another, then back to the original "room" if `MOVE_TO` is issued again. Currently, only two "rooms" are implemented. Characters can be configured (via `unseen: true`) to be known to the ADM, but not in the current room, so that the ADM can `MOVE_TO` that character. Any "seen" characters in the scene then become "unseen" after the move, and all previously "unseen" characters become "seen" (e.g., `unseen: false`). Unseen characters can be configured to have certain properties known to the ADM prior to being seen. Some or all domain-specific actions may not be valid for unseen characters; check the domain-specific README.
+4. How does `elapsed_time` work?
    * Whenever an action is taken, a configurable amount of time passes.  The `elapsed_time` property of the `state` object contains a running total of time passed (in seconds).
-   * **NOTE**: at present, the passage of time has **no effect** on patients and is simply a construct of the TA3 server, although scenario designers can use it as a condition for transition from one logical scene to the next.
-   * **NOTE**: the elapsed time for each action has not been vetted by ITM medical SMEs and should not be used in decision-making.
-8. What exactly is `unstructured_postassess` in the `character` object?  It's always `None`.
-   * The `unstructured_postassess` property is for TA1 scenario designers to provide an updated unstructured text description of the character and/or his/her injuries. After the character is assessed/visited, the contents of the `unstructured_postassess` property are copied to the `unstructured` property.  It's always `None` because it is not exposed to ADMs, only copied to `unstructured`, which is exposed to ADMs.
-9. In training sessions, after the ADM takes its first action, the session alignment is usually 0.5.  Why is this?
-    * If the ADM's first action doesn't result in a probe response, alignment is undefined. The `AlignmentResults` object does not allow for a `score` of `None`, and requires a value between 0 and 1. So the TA3 server responds with 0.5.
-10. What happens if I treat an `Amputation` injury with a `Nasopharyngeal airway` treatment?
-    * As long as there are sufficient supplies, the TA3 Server will not reject an `APPLY_TREATMENT` attempt. However, not all treatments actually treat an injury (like in the example above). In these cases, the supply will be used, time will elapse, the character will be `visited`, and certain vitals will be revealed, but the injury's `status` will NOT change to `treated`. The mapping of correct treatments to injury types matches the behavior in the Unity simulator.
-11. What `location` should I use when applying a `Blanket` to a patient?
-    * When applying a `Blanket`, `location` is required but ignored-- the effect is the same: `Character.has_blanket` is set to True.
-12. My ADM correctly treated an Amputation injury with a Tourniquet, but nothing happened, except for time advancing. Why?
-    * This can happen for one of two reasons:
-      * Scenario designers have the ability to alter the state after any action, potentially overwriting or overriding ADM actions, giving the appearance of erasing history.  Typically, if a scenarios calls for actions to be "interrupted" or "intent only," they will configure action mappings to be `intent_only`, so ADMs know that they are expressing an intention instead of taking an action.
-      * If an ADM attempts to treat an injury that is already treated, then nothing will change other than a little bit of time passing.  If the character was previously unvisited, then basic vitals and other discoverable injuries will NOT be revealed as they normally would be after a treatment attempt.
-13. Sometimes the actions returned in `get_available_actions` are "fully qualified" (with all `parameters`), but other times they are not. How do we know if the action will trigger its effects?
-    * TA1 scenario designers specify action mappings that include the necessary action parameters to trigger a probe response. If an action mapping contains `APPLY_TREATMENT` with a `character_id` but no `parameters`, then TA2 will have to fill in parameters (e.g., `treatment` and `location`), but any treatment of the character will result in probe response.
-    * **NOTE** It's essential that the `action_id` of the TA2 action match the `action_id` of the original, corresponding action from `get_available_actions`.  Otherwise, the probe response might not be sent.
-14. Why do taken actions sometimes disappear from `get_available_actions`, but other times don't?
-    * TA1 scenario designers configure mappings from actions to probe responses. They can configure whether a given mapping is `repeatable` or not. If an unrepeatable action is taken by the ADM, and conditions *aren't* met for a scene change, then that action will be removed from the list of available actions.  Actions that aren't part of TA1 action mappings that aren't explicitly *restricted* also appear in the list of available actions (except for certain actions, depending on the state). These actions are always repeatable.
-15. Are `action_id`s (as returned by `get_available_actions`) giving away at evaluation time what actions are important?
-    * TA1 scenario designers assign `action_id`s to all actions in a scene's action mapping configuration.  Other actions in the ADM decision space are added at runtime unless they are explicitly restricted by TA1. The other actions are added to match more closely what a human experiences in the VR simulator.
-    * The actions added by TA3 have invariant `action_id`s, and as such an ADM may be able to discern which actions were configured by TA1 vs. added by the TA3 server. The TA1 actions are those which *may* result in a probe response, depending on configured conditions.
-    * Although actions that elicit probe responses can be considered more important, they are not providing the right (or better aligned) answers. If the program considers this an issue, we can come up with conventions for action IDs. Maybe all actions must have `action_id`s of `action-n` whether configured by TA1 or added by the TA3 server.
-16. When should I use `/ta2/takeAction` vs. `/ta2/intendAction`?  What's the difference?
-    * Typically, ADMs should use `/ta2/takeAction`.  Sometimes scenario designers want the ADM to specify the *intent* to take an action, or want to interrupt an action before it happens.  In these cases, some or all `Actions` returned by `get_available_actions` will have the `intent_action` property set to `True`.  If you are selecting one of these actions, then call `/ta2/intendAction`.
-    * The API for these calls is very similar.  In both cases, they reject (via 400 error code) when there's a mismatch of action type (e.g., using `/ta2/takeAction` for an intent action and vice versa). Requests and responses have the same format.
-    * The main difference is that when taking an action via `/ta2/takeAction`, ADMs can expect that their actions are reflected in the state (e.g., a supply is decremented after a correct treatment), whereas intending an action via `/ta2/intendAction` may not result in a change of state.  Please note that in all cases, the state might appear completely different from prior to the taken/intended action, for example if the action transitions the scenario to the next narrative scene.
-17. What are Events and what are the semantics for interpreting them in the scene?<br>
+   * **NOTE**: at present, the passage of time has **no effect** on characters or anything else, and is simply a construct of the TA3 server, although scenario designers can use it as a condition for transition from one logical scene to the next.
+5. In training sessions, after the ADM takes its first action, the session alignment is usually 0.5.  Why is this?
+   * If the ADM's first action doesn't result in a probe response, alignment is undefined. The `AlignmentResults` object does not allow for a `score` of `None`, and requires a value between 0 and 1. So the TA3 server responds with 0.5.
+6. Why do taken actions sometimes disappear from `get_available_actions`, but other times don't?
+   * TA1 scenario designers configure mappings from actions to probe responses. They can configure whether a given mapping is `repeatable` or not. If an unrepeatable action is taken by the ADM, and conditions *aren't* met for a scene change, then that action will be removed from the list of available actions.  Actions that aren't part of TA1 action mappings that aren't explicitly *restricted* also appear in the list of available actions (except for certain actions, depending on the state). These actions are always repeatable.
+7. Are `action_id`s (as returned by `get_available_actions`) giving away at evaluation time what actions are important?
+   * TA1 scenario designers assign `action_id`s to all actions in a scene's action mapping configuration.  Other actions in the ADM decision space are added at runtime unless they are explicitly restricted by TA1. The other actions are added to match more closely what a human experiences in the VR simulator.
+   * The actions added by TA3 have invariant `action_id`s, and as such an ADM may be able to discern which actions were configured by TA1 vs. added by the TA3 server. The TA1 actions are those which *may* result in a probe response, depending on configured conditions.
+   * Although actions that elicit probe responses can be considered more important, they are not providing the right (or better aligned) answers. If the program considers this an issue, we can come up with conventions for action IDs. Maybe all actions must have `action_id`s of `action-n` whether configured by TA1 or added by the TA3 server.
+8. When should I use `/ta2/takeAction` vs. `/ta2/intendAction`?  What's the difference?
+   * Typically, ADMs should use `/ta2/takeAction`.  Sometimes scenario designers want the ADM to specify the *intent* to take an action, or want to interrupt an action before it happens.  In these cases, some or all `Actions` returned by `get_available_actions` will have the `intent_action` property set to `True`.  If you are selecting one of these actions, then call `/ta2/intendAction`.
+   * The API for these calls is very similar.  In both cases, they reject (via 400 error code) when there's a mismatch of action type (e.g., using `/ta2/takeAction` for an intent action and vice versa). Requests and responses have the same format.
+   * The main difference is that when taking an action via `/ta2/takeAction`, ADMs can expect that their actions are reflected in the state (e.g., a supply is decremented after a correct treatment), whereas intending an action via `/ta2/intendAction` may not result in a change of state.  Please note that in all cases, the state might appear completely different from prior to the taken/intended action, for example if the action transitions the scenario to the next narrative scene.
+9. What are Events and what are the semantics for interpreting them in the scene?<br>
     Events communicate information from the scenario to ADM.  Each event has unstructured text and one of the following event types:
     * `change`: signifies a change in state from one known value to another.
       * `source` is the entity telling of the state change
@@ -206,12 +151,10 @@ Further details can be found in the ITM Server FAQ below.
       * `action_id` is the ID of the ordered action; the action_id matches an action from `get_available_state`
 
     The `relevant_state` property is a list of string paths within the `State` object, in which indexed lists are context-sensitive:
-    * for `Aid` or a `Character`, it's the `id`
-    * for `Supplies`, it's the `type`
+    * for `Character`, it's the `id`
     * for `Threat`, it's the `threat_type`
-    * for `Injury`, it's the `location`
-
-18. What are `MESSAGE` actions and what are the semantics for interpreting them in the action space?
+    * Other relevant state may be domain-specific
+10. What are `MESSAGE` actions and what are the semantics for interpreting them in the action space?
     * Messages communicate different kinds of actions from the ADM to the server.  They can be thought of as the opposite side of the same coin of Events, and are similar in design.
     * All `MESSAGE` actions and their parameters are pre-configured in the scenario; the ADM shouldn't change any properties (including `parameters`) from what they received in `get_available_actions()`.
     * If the recipient of the message is a character in the scene, then the action's `character_id` is the recipient of the message.  If not, then the `recipient` parameter describes the entity the ADM is addressing (taken from `EntityTypeEnum`).
@@ -221,7 +164,7 @@ Further details can be found in the ITM Server FAQ below.
       * `delegate`: have the recipient make the decision; contains an `action_type` parameter the type of action the ADM is delegating
       * `deny`: forbid/prevent something from happening; may contain an `object` parameter to indicate who is being denied/prevented
       * `justify`: provide a rationale for the previous ADM action; contains `relevant_state` to specify the state that justifies the action. Please note that there may be multiple relevant states specified.  See Events FAQ for more on `relevant_state`.
-        * Multiple elements of `relevant_state` are expressed as a comma-separated list with elements enclosed in brackets, e.g., `"relevant_state": "[character[shooter].intent], [character[victim].injuries]"`
+        * Multiple elements of `relevant_state` are expressed as a comma-separated list with elements enclosed in brackets, e.g., `"relevant_state": "[character[Mike].rapport], [character[Frank].demographics.age]"`
       * `recommend`: recommend a course of action; contains an `action_type` parameter for the recommended action; may contain an `object` parameter to signify the character_id or `EntityTypeEnum` upon whom the action is performed, or possibly the thing that is being recommended if it is not an action type
       * `wait`: tell the recipient to wait
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ pip3 install -r requirements.txt
  Run `itm_minimal_runner.py` in the root directory:
 
 ```
-usage: itm_minimal_runner.py [-h] --name adm_name --session session_type [--profile adm_profile] [--count scenario_count]
-                             [--training training_mode] [--scenario scenario_id]
+usage: itm_minimal_runner.py [-h] --name adm_name --session session_type [--profile adm_profile] [--domain domain_name]
+                             [--count scenario_count] [--training training_mode] [--scenario scenario_id]
 
 Runs ADM simulator.
 
@@ -57,6 +57,7 @@ options:
   --name adm_name          Specify the ADM name
   --session session_type   Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
   --profile adm_profile    Specify the ADM profile in terms of its alignment strategy
+  --domain domain_name     Specify the domain for the session, or use the server default
   --count scenario_count   Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
                            supported in `eval` sessions.
   --training training_mode Put the server in either `full` or `solo` training mode in which it returns the KDMA association for each
@@ -71,13 +72,15 @@ The Human input simulator is used for testing specific action/parameter sequence
 Inside the root directory, run `itm_human_input.py`:
 
 ```
-usage: itm_human_input.py [-h] --session session_type [--count scenario_count] [--training training_mode] [--scenario scenario_id]
+usage: itm_human_input.py [-h] --session session_type [--domain domain_name] [--count scenario_count]
+                          [--training training_mode] [--scenario scenario_id]
 
 Runs Human input simulator.
 
 options:
   -h, --help               Show this help message and exit
   --session session_type   Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.
+  --domain domain_name     Specify the domain for the session, or use the server default
   --count scenario_count   Run the specified number of scenarios. Otherwise, will run scenarios in accordance with server defaults. Not
                            supported in `eval` sessions.
   --training training_mode Put the server in either `full` or `solo` training mode in which it returns the KDMA association for each

--- a/docs/ItmTa2EvalApi.md
+++ b/docs/ItmTa2EvalApi.md
@@ -314,7 +314,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **start_session**
-> str start_session(adm_name, session_type, adm_profile=adm_profile, kdma_training=kdma_training, max_scenarios=max_scenarios)
+> str start_session(adm_name, session_type, adm_profile=adm_profile, domain=domain, kdma_training=kdma_training, max_scenarios=max_scenarios)
 
 Start a new session
 
@@ -333,12 +333,13 @@ api_instance = swagger_client.ItmTa2EvalApi()
 adm_name = 'adm_name_example' # str | A self-assigned ADM name.
 session_type = 'session_type_example' # str | the type of session to start (`eval`, `test`, or a TA1 name)
 adm_profile = 'adm_profile_example' # str | a profile of the ADM in terms of its alignment strategy (optional)
+domain = 'domain_example' # str | A domain supported by the ITM evaluation server (optional)
 kdma_training = 'kdma_training_example' # str | whether this is a `full`, `solo`, or non-training session with TA2 (optional)
 max_scenarios = 56 # int | the maximum number of scenarios requested, not supported in `eval` sessions (optional)
 
 try:
     # Start a new session
-    api_response = api_instance.start_session(adm_name, session_type, adm_profile=adm_profile, kdma_training=kdma_training, max_scenarios=max_scenarios)
+    api_response = api_instance.start_session(adm_name, session_type, adm_profile=adm_profile, domain=domain, kdma_training=kdma_training, max_scenarios=max_scenarios)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling ItmTa2EvalApi->start_session: %s\n" % e)
@@ -351,6 +352,7 @@ Name | Type | Description  | Notes
  **adm_name** | **str**| A self-assigned ADM name. | 
  **session_type** | **str**| the type of session to start (&#x60;eval&#x60;, &#x60;test&#x60;, or a TA1 name) | 
  **adm_profile** | **str**| a profile of the ADM in terms of its alignment strategy | [optional] 
+ **domain** | **str**| A domain supported by the ITM evaluation server | [optional] 
  **kdma_training** | **str**| whether this is a &#x60;full&#x60;, &#x60;solo&#x60;, or non-training session with TA2 | [optional] 
  **max_scenarios** | **int**| the maximum number of scenarios requested, not supported in &#x60;eval&#x60; sessions | [optional] 
 

--- a/docs/ThreatState.md
+++ b/docs/ThreatState.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**unstructured** | **str** | Natural language, plain text description of environmental threats | 
+**unstructured** | **str** | Natural language, plain text description of environmental risks or threats | 
 **threats** | [**list[Threat]**](Threat.md) | A list of pairs of threat types with a severity descriptor | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/itm/itm_human_scenario_runner.py
+++ b/itm/itm_human_scenario_runner.py
@@ -27,11 +27,12 @@ class TagTypes(Enum):
 ACTIONS_WITHOUT_CHARACTERS = ["DIRECT_MOBILE_CHARACTERS", "END_SCENE", "MESSAGE", "SEARCH", "SITREP"]
 
 class ITMHumanScenarioRunner(ScenarioRunner):
-    def __init__(self, session_type, kdma_training=None, max_scenarios=-1, scenario_id=None):
+    def __init__(self, session_type, domain=None, kdma_training=None, max_scenarios=-1, scenario_id=None):
         super().__init__()
         self.username = session_type + " ITM Human"
         self.session_type = session_type
         self.kdma_training = kdma_training
+        self.domain = domain
         if max_scenarios > 0:
             self.max_scenarios = max_scenarios
         else:
@@ -203,9 +204,9 @@ class ITMHumanScenarioRunner(ScenarioRunner):
     def start_session_operation(self, username):
         if self.session_id is None:
             if self.max_scenarios is None:
-                self.session_id = self.itm.start_session(username, self.session_type, kdma_training=self.kdma_training)
+                self.session_id = self.itm.start_session(username, self.session_type, domain=self.domain, kdma_training=self.kdma_training)
             else:
-                self.session_id = self.itm.start_session(username, self.session_type, kdma_training=self.kdma_training, max_scenarios=self.max_scenarios)
+                self.session_id = self.itm.start_session(username, self.session_type, domain=self.domain, kdma_training=self.kdma_training, max_scenarios=self.max_scenarios)
             response = self.session_id
         else:
             response = "Session is already started."

--- a/itm_human_input.py
+++ b/itm_human_input.py
@@ -6,6 +6,8 @@ def main():
     parser = argparse.ArgumentParser(description='Runs Human input simulator.')
     parser.add_argument('--session', required=True, metavar='session_type', help=\
                         'Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.')
+    parser.add_argument('--domain', metavar='domain_name', required=False,
+                        help='Specify the domain for the session, or use the server default')
     parser.add_argument('--count', type=int, metavar='scenario_count', help=\
                         'Run the specified number of scenarios. Otherwise, will run scenarios in '
                         'accordance with server defaults. Not supported in `eval` sessions.')
@@ -47,9 +49,9 @@ def main():
         parser.error("--scenario is incompatible with --count.")
 
     if scenario_id:
-        runner = ITMHumanScenarioRunner(session_type, args.training, scenario_count, scenario_id)
+        runner = ITMHumanScenarioRunner(session_type, args.domain, args.training, scenario_count, scenario_id)
     else:
-        runner = ITMHumanScenarioRunner(session_type, args.training, scenario_count)
+        runner = ITMHumanScenarioRunner(session_type, args.domain, args.training, scenario_count)
     runner.run()
 
 if __name__ == "__main__":

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -136,6 +136,8 @@ def main():
                         'Specify session type. Session type must be `test`, `eval`, `adept`, or `soartech`.')
     parser.add_argument('--profile', metavar='adm_profile', required=False,
                         help='Specify the ADM profile in terms of its alignment strategy')
+    parser.add_argument('--domain', metavar='domain_name', required=False,
+                        help='Specify the domain for the session, or use the server default')
     parser.add_argument('--count', type=int, metavar='scenario_count', help=\
                         'Run the specified number of scenarios. Otherwise, will run scenarios in '
                         'accordance with server defaults. Not supported in `eval` sessions.')
@@ -199,12 +201,14 @@ def main():
             session_id = itm.start_session(
                 adm_name=args.name,
                 adm_profile=args.profile,
+                domain=args.domain,
                 session_type='eval'
             )
         else:
             session_id = itm.start_session(
                 adm_name=args.name,
                 adm_profile=args.profile,
+                domain=args.domain,
                 session_type=session_type,
                 max_scenarios=scenario_count,
                 kdma_training=args.training

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -47,6 +47,14 @@ paths:
           schema:
             type: string
             example: eval
+        - name: domain
+          in: query
+          description: A domain supported by the ITM evaluation server
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: string
         - name: kdma_training
           in: query
           description: "whether this is a `full`, `solo`, or non-training session with TA2"

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -412,7 +412,7 @@ components:
         - id
         - name
       type: object
-      description: a triage scenario requiring decisions by a medic
+      description: a scenario requiring decisions by a decision-maker
       properties:
         id:
           type: string
@@ -420,7 +420,6 @@ components:
         name:
           type: string
           description: human-readable scenario name, not necessarily unique
-          example: IED Explosion
         first_scene:
           type: string
           description: indicates the first/opening scene ID in the scenario
@@ -512,13 +511,6 @@ components:
           description: list of KDMAs to align to
           items:
             $ref: "#/components/schemas/KDMA_Value"
-      example:
-        kdma_values:
-          - value: 0.8
-            kdma: mission
-          - value: 0.5
-            kdma: fairness
-        id: id
     KDE_Data:
       type: object
       description: KDE Objects representing a KDMA Measurement
@@ -541,7 +533,6 @@ components:
         kdma:
           type: string
           description: Name of KDMA
-          example: mission
         value:
           type: number
           format: float
@@ -562,9 +553,6 @@ components:
           description: KDE Objects representing a KDMA Measurement
           additionalProperties:
             $ref: "#/components/schemas/KDE_Data"
-      example:
-        value: 0.8
-        kdma: mission
     BaseState:
       type: object
       required:
@@ -784,22 +772,21 @@ components:
         - unstructured
         - threats
       type: object
-      description: Description of the current threat to the characters
+      description: Description of the current risks or threats to the characters
       properties:
         unstructured:
           type: string
-          description: Natural language, plain text description of environmental threats
-          example: No additional threats are detected
+          description: Natural language, plain text description of environmental risks or threats
         threats:
           type: array
           description: A list of pairs of threat types with a severity descriptor
           items:
             $ref: "#/components/schemas/Threat"
       example:
-        unstructured: Gunfire can be heard in the surrounding area
+        unstructured: Gunshots have been reported in the surrounding area
         threats:
           - type: gunfire
-            severity: severe
+            severity: moderate
     Threat:
       required:
         - threat_type
@@ -841,13 +828,11 @@ components:
           description: An array of relevant state for the Event
           items:
             description: >
-              string paths within the `State` object, in which indexed lists are context-sensitive:
-              for an aid or a character, it's the id;
-              for a supply, it's the type;
+              string paths within the `State` object, in which indexed lists are context-sensitive and usually domain-specific:
+              for a character, it's the id;
               for a threat, it's the threat_type;
-              for an injury, it's the location
             type: string
-            example: environment.decision_environment.aid[civilian_facility].max_transport
+            example: threat_state.threats[gunshots].threat_type
     Supplies:
       required:
         - quantity
@@ -883,7 +868,6 @@ components:
         id:
           type: string
           description: A unique character ID throughout the scenario
-          example: Soldier_01
         name:
           type: string
           description: display name, as in a dashboard
@@ -891,7 +875,7 @@ components:
         unstructured:
           type: string
           description: Natural language, plain text description of the character
-          example: 22 YO male Marine hit by an IED. Puncture wound on the left side of the neck.
+          example: 22-year-old male with brown hair
         demographics:
           $ref: "#/components/schemas/Demographics"
         rapport:
@@ -902,7 +886,7 @@ components:
           default: false
     DomainCharacter:
       type: object
-      description: a character in the scene, including injured patients, civilians, medics, etc.
+      description: a character in the scene, which might be domain-specific
       properties:
         unstructured_postassess:
           type: string
@@ -1093,7 +1077,7 @@ components:
           items:
             $ref: "#/components/schemas/ActionTypeEnum"
           example:
-            - CHECK_ALL_VITALS
+            - SEARCH
         transition_semantics:
           $ref: "#/components/schemas/SemanticTypeEnum"
         transitions:
@@ -1118,7 +1102,6 @@ components:
         unstructured:
           type: string
           description: Natural language, plain text description of the action
-          example: "Check Mike's pulse."
         character_id:
           type: string
           description: The ID of the character being acted upon
@@ -1130,12 +1113,10 @@ components:
           additionalProperties:
             type: string
           example:
-            - treatment: Tourniquet
-            - location: right forearm
+            - character_id: Mike
         justification:
           type: string
           description: A justification of the action taken
-          example: Character is the VIP of the scenario
         kdma_association:
           type: object
           additionalProperties:
@@ -1144,8 +1125,6 @@ components:
             minimum: 0.0
             maximum: 1.0
           description: KDMA associations for this choice, if provided by TA1
-          example:
-            - Mission: 0.8
     ActionMapping:
       required:
         - action_id
@@ -1165,7 +1144,6 @@ components:
         unstructured:
           type: string
           description: Natural language, plain text description of the action
-          example: "Check Mike's pulse."
         repeatable:
           type: boolean
           default: false
@@ -1185,8 +1163,7 @@ components:
           additionalProperties:
             type: string
           example:
-            - treatment: Tourniquet
-            - location: right forearm
+            - character_id: Mike
         probe_id:
           type: string
           description: A valid probe_id from the appropriate TA1
@@ -1204,8 +1181,6 @@ components:
             minimum: 0.0
             maximum: 1.0
           description: KDMA associations for this choice, if provided by TA1
-          example:
-            - Mission: 0.8
         action_condition_semantics:
           $ref: "#/components/schemas/SemanticTypeEnum"
         action_conditions:
@@ -1859,7 +1834,7 @@ components:
         - none
     RapportEnum:
       type: string
-      description: A measure of closeness or affinity towards the player/medic
+      description: A measure of closeness or affinity towards the decision-maker
       enum:
         - loathing
         - dislike

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -659,6 +659,7 @@ class ItmTa2EvalApi(object):
         :param str adm_name: A self-assigned ADM name. (required)
         :param str session_type: the type of session to start (`eval`, `test`, or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
+        :param str domain: A domain supported by the ITM evaluation server
         :param str kdma_training: whether this is a `full`, `solo`, or non-training session with TA2
         :param int max_scenarios: the maximum number of scenarios requested, not supported in `eval` sessions
         :return: str
@@ -685,6 +686,7 @@ class ItmTa2EvalApi(object):
         :param str adm_name: A self-assigned ADM name. (required)
         :param str session_type: the type of session to start (`eval`, `test`, or a TA1 name) (required)
         :param str adm_profile: a profile of the ADM in terms of its alignment strategy
+        :param str domain: A domain supported by the ITM evaluation server
         :param str kdma_training: whether this is a `full`, `solo`, or non-training session with TA2
         :param int max_scenarios: the maximum number of scenarios requested, not supported in `eval` sessions
         :return: str
@@ -692,7 +694,7 @@ class ItmTa2EvalApi(object):
                  returns the request thread.
         """
 
-        all_params = ['adm_name', 'session_type', 'adm_profile', 'kdma_training', 'max_scenarios']  # noqa: E501
+        all_params = ['adm_name', 'session_type', 'adm_profile', 'domain', 'kdma_training', 'max_scenarios']  # noqa: E501
         all_params.append('async_req')
         all_params.append('_return_http_data_only')
         all_params.append('_preload_content')
@@ -727,6 +729,8 @@ class ItmTa2EvalApi(object):
             query_params.append(('adm_profile', params['adm_profile']))  # noqa: E501
         if 'session_type' in params:
             query_params.append(('session_type', params['session_type']))  # noqa: E501
+        if 'domain' in params:
+            query_params.append(('domain', params['domain']))  # noqa: E501
         if 'kdma_training' in params:
             query_params.append(('kdma_training', params['kdma_training']))  # noqa: E501
         if 'max_scenarios' in params:

--- a/swagger_client/models/threat_state.py
+++ b/swagger_client/models/threat_state.py
@@ -49,7 +49,7 @@ class ThreatState(object):
     def unstructured(self):
         """Gets the unstructured of this ThreatState.  # noqa: E501
 
-        Natural language, plain text description of environmental threats  # noqa: E501
+        Natural language, plain text description of environmental risks or threats  # noqa: E501
 
         :return: The unstructured of this ThreatState.  # noqa: E501
         :rtype: str
@@ -60,7 +60,7 @@ class ThreatState(object):
     def unstructured(self, unstructured):
         """Sets the unstructured of this ThreatState.
 
-        Natural language, plain text description of environmental threats  # noqa: E501
+        Natural language, plain text description of environmental risks or threats  # noqa: E501
 
         :param unstructured: The unstructured of this ThreatState.  # noqa: E501
         :type: str


### PR DESCRIPTION
See corresponding [server PR](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/119).

Make sure the updated CLI works, and the README makes sense, and properly separates generic and domain-specific content.