### PR TITLE
ITM-497:  Add action validation to API

### DIFF
--- a/README-API.md
+++ b/README-API.md
@@ -96,6 +96,7 @@ Class | Method | HTTP request | Description
 *ItmTa2EvalApi* | [**start_scenario**](docs/ItmTa2EvalApi.md#start_scenario) | **GET** /ta2/scenario | Get the next scenario
 *ItmTa2EvalApi* | [**start_session**](docs/ItmTa2EvalApi.md#start_session) | **GET** /ta2/startSession | Start a new session
 *ItmTa2EvalApi* | [**take_action**](docs/ItmTa2EvalApi.md#take_action) | **POST** /ta2/takeAction | Take an action within a scenario
+*ItmTa2EvalApi* | [**validate_action**](docs/ItmTa2EvalApi.md#validate_action) | **POST** /ta2/validateAction | Validate an action within a scenario
 
 
 ## Documentation For Models

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ def outputDirectory = "swagger_client"
 def testDirectory = "test"
 def docsDirectory = "docs"
 def readmeDest = "${projectDir}"
+def apiFilename = "itm_ta2_eval_api.py"
 
 task swaggerClean(type: Delete) {
     doFirst {
@@ -76,6 +77,11 @@ task postGeneration() {
         copy {
             from "${generatedApiDirectory}/${docsDirectory}/"
             into docsDirectory
+        }
+
+        copy {
+            from "${generatedApiDirectory}/${outputDirectory}/api/${apiFilename}"
+            into "${outputDirectory}/api"
         }
 
         copy {

--- a/docs/ItmTa2EvalApi.md
+++ b/docs/ItmTa2EvalApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**start_scenario**](ItmTa2EvalApi.md#start_scenario) | **GET** /ta2/scenario | Get the next scenario
 [**start_session**](ItmTa2EvalApi.md#start_session) | **GET** /ta2/startSession | Start a new session
 [**take_action**](ItmTa2EvalApi.md#take_action) | **POST** /ta2/takeAction | Take an action within a scenario
+[**validate_action**](ItmTa2EvalApi.md#validate_action) | **POST** /ta2/validateAction | Validate an action within a scenario
 
 
 # **get_alignment_target**
@@ -603,6 +604,78 @@ No authorization required
 |-------------|-------------|------------------|
 **200** | Successful operation, scenario state returned |  -  |
 **400** | Invalid action or Session ID, or specified an intent action |  -  |
+**500** | An exception occurred on the server; see returned error string. |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **validate_action**
+> str validate_action(session_id, action=action)
+
+Validate an action within a scenario
+
+Validate that the specified Action is structually and contextually valid within a scenario
+
+### Example
+
+
+```python
+import swagger_client
+from swagger_client.models.action import Action
+from swagger_client.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = swagger_client.Configuration(
+    host = "http://localhost"
+)
+
+
+# Enter a context with an instance of the API client
+with swagger_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = swagger_client.ItmTa2EvalApi(api_client)
+    session_id = 'session_id_example' # str | a unique session_id, as returned by /ta2/startSession
+    action = swagger_client.Action() # Action | Encapsulation of an action to be validated by a DM in the context of the scenario (optional)
+
+    try:
+        # Validate an action within a scenario
+        api_response = api_instance.validate_action(session_id, action=action)
+        print("The response of ItmTa2EvalApi->validate_action:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling ItmTa2EvalApi->validate_action: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **session_id** | **str**| a unique session_id, as returned by /ta2/startSession | 
+ **action** | [**Action**](Action.md)| Encapsulation of an action to be validated by a DM in the context of the scenario | [optional] 
+
+### Return type
+
+**str**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: text/plain
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | Successful operation, returns &#39;valid action&#39;/&#39;valid intention&#39; if the action/intention is valid, otherwise a string describing why it is invalid |  -  |
+**400** | Invalid Session ID |  -  |
 **500** | An exception occurred on the server; see returned error string. |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/itm_minimal_runner.py
+++ b/itm_minimal_runner.py
@@ -235,6 +235,11 @@ def main():
                 action = get_next_action(scenario, state, alignment_target, actions, paths, action_path_index, path_index)
                 print(f'Action type: {action.action_type}; Character ID: {action.character_id}; parameters: {action.parameters}')
                 action_path_index+=1
+                valid_response = itm.validate_action(session_id=session_id, action=action)
+                if (action.intent_action and valid_response != 'valid intention') or \
+                    (not action.intent_action and valid_response != 'valid action'):
+                    print(f"Client error: invalid {'intention' if action.intent_action else 'action'} generated, message: \"{valid_response}\".  Exiting.")
+                    return
                 state = itm.take_action(session_id=session_id, action=action) if not action.intent_action else itm.intend_action(session_id=session_id, action=action)
                 if state.meta_info.scene_id != current_scene:
                     current_scene = state.meta_info.scene_id

--- a/swagger/base_swagger.yaml
+++ b/swagger/base_swagger.yaml
@@ -405,6 +405,50 @@ paths:
                 type: string
                 x-content-type: text/plain
       x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
+  /ta2/validateAction:
+    post:
+      description: Validate that the specified Action is structually and contextually valid within a scenario
+      operationId: validate_action
+      parameters:
+      - description: "a unique session_id, as returned by /ta2/startSession"
+        explode: true
+        in: query
+        name: session_id
+        required: true
+        schema:
+          type: string
+        style: form
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Action"
+        description: Encapsulation of an action to be validated by a DM in the context of the
+          scenario
+      responses:
+        "200":
+          description: "Successful operation, returns 'valid action'/'valid intention'
+            if the action/intention is valid, otherwise a string describing why it is invalid"
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: "'valid action'/'valid intention' if the action/intention is valid,
+                  otherwise a string describing why it is invalid"
+                x-content-type: text/plain
+        "400":
+          description: "Invalid Session ID"
+        "500":
+          content:
+            text/plain:
+              schema:
+                type: string
+                x-content-type: text/plain
+          description: An exception occurred on the server; see returned error string.
+      summary: Validate an action within a scenario
+      tags:
+      - itm-ta2-eval
+      x-openapi-router-controller: swagger_server.controllers.itm_ta2_eval_controller
 components:
   schemas:
     Scenario:

--- a/swagger_client/api/itm_ta2_eval_api.py
+++ b/swagger_client/api/itm_ta2_eval_api.py
@@ -2438,3 +2438,299 @@ class ItmTa2EvalApi:
         )
 
 
+
+
+    @validate_call
+    def validate_action(
+        self,
+        session_id: Annotated[StrictStr, Field(description="a unique session_id, as returned by /ta2/startSession")],
+        action: Annotated[Optional[Action], Field(description="Encapsulation of an action to be validated by a DM in the context of the scenario")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> str:
+        """Validate an action within a scenario
+
+        Validate that the specified Action is structually and contextually valid within a scenario
+
+        :param session_id: a unique session_id, as returned by /ta2/startSession (required)
+        :type session_id: str
+        :param action: Encapsulation of an action to be validated by a DM in the context of the scenario
+        :type action: Action
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._validate_action_serialize(
+            session_id=session_id,
+            action=action,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+            '400': None,
+            '500': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def validate_action_with_http_info(
+        self,
+        session_id: Annotated[StrictStr, Field(description="a unique session_id, as returned by /ta2/startSession")],
+        action: Annotated[Optional[Action], Field(description="Encapsulation of an action to be validated by a DM in the context of the scenario")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[str]:
+        """Validate an action within a scenario
+
+        Validate that the specified Action is structually and contextually valid within a scenario
+
+        :param session_id: a unique session_id, as returned by /ta2/startSession (required)
+        :type session_id: str
+        :param action: Encapsulation of an action to be validated by a DM in the context of the scenario
+        :type action: Action
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._validate_action_serialize(
+            session_id=session_id,
+            action=action,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+            '400': None,
+            '500': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def validate_action_without_preload_content(
+        self,
+        session_id: Annotated[StrictStr, Field(description="a unique session_id, as returned by /ta2/startSession")],
+        action: Annotated[Optional[Action], Field(description="Encapsulation of an action to be validated by a DM in the context of the scenario")] = None,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """Validate an action within a scenario
+
+        Validate that the specified Action is structually and contextually valid within a scenario
+
+        :param session_id: a unique session_id, as returned by /ta2/startSession (required)
+        :type session_id: str
+        :param action: Encapsulation of an action to be validated by a DM in the context of the scenario
+        :type action: Action
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._validate_action_serialize(
+            session_id=session_id,
+            action=action,
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "str",
+            '400': None,
+            '500': "str",
+        }
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _validate_action_serialize(
+        self,
+        session_id,
+        action,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> RequestSerialized:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[
+            str, Union[str, bytes, List[str], List[bytes], List[Tuple[str, bytes]]]
+        ] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        if session_id is not None:
+            
+            _query_params.append(('session_id', session_id))
+            
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+        if action is not None:
+            _body_params = action
+
+
+        # set the HTTP header `Accept`
+        if 'Accept' not in _header_params:
+            _header_params['Accept'] = self.api_client.select_header_accept(
+                [
+                    'text/plain'
+                ]
+            )
+
+        # set the HTTP header `Content-Type`
+        if _content_type:
+            _header_params['Content-Type'] = _content_type
+        else:
+            _default_content_type = (
+                self.api_client.select_header_content_type(
+                    [
+                        'application/json'
+                    ]
+                )
+            )
+            if _default_content_type is not None:
+                _header_params['Content-Type'] = _default_content_type
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/ta2/validateAction',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+

--- a/test/test_itm_ta2_eval_api.py
+++ b/test/test_itm_ta2_eval_api.py
@@ -82,6 +82,13 @@ class TestItmTa2EvalApi(unittest.TestCase):
         """
         pass
 
+    def test_validate_action(self) -> None:
+        """Test case for validate_action
+
+        Validate an action within a scenario
+        """
+        pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
See [server PR](https://github.com/NextCenturyCorporation/itm-evaluation-server/pull/126).

This PR also copies the generated swagger API file to the client, so that when an endpoint is added to the API, the client is automatically updated.